### PR TITLE
Add environment configuration and requirements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+OPENAI_API_KEY=your-openai-key
+OPENAI_MODEL=gpt-4-turbo
+REPO_URL=https://github.com/your/repository

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 # Venv
 venv/
 
+.env

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ This repository contains a demo SQLite database (`demo_sirket.db`) and a simple 
 ## Setup
 1. Install dependencies:
    ```bash
-   pip install pandas matplotlib seaborn openai
+   pip install -r requirements.txt
    ```
-2. Set your OpenAI API key in the environment:
+2. Copy the example environment file and fill in your details:
    ```bash
-   export OPENAI_API_KEY=your-key
+   cp .env.example .env
+   # edit .env with your values
    ```
+   The `.env` file should define `OPENAI_API_KEY`, `OPENAI_MODEL` and `REPO_URL`.
 
 ## Usage
 Run the interactive application:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+matplotlib
+seaborn
+openai
+python-dotenv
+Faker


### PR DESCRIPTION
## Summary
- create `.env.example` with common configuration keys
- load environment variables using `python-dotenv`
- allow model selection through `OPENAI_MODEL` variable
- show repository URL when present
- document new setup steps in README
- provide `requirements.txt` and ignore local `.env`

## Testing
- `python -m py_compile nl2sql_app.py`

------
https://chatgpt.com/codex/tasks/task_b_68754a3bee18832f97b3367e1af6ddc9