### PR TITLE
Add progress indicator to React demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ The backend should respond with:
 }
 ```
 The frontend displays the SQL, renders the table or chart using the provided data, and keeps a history of recent queries.
+While the query runs, the UI shows a short progress indicator below the form.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -53,8 +53,41 @@ pre.sql {
   padding: 0.5rem;
 }
 
+.loading {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 @media (max-width: 600px) {
   .app {
     padding: 0.5rem;
+  }
+}
+
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  background: #eee;
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-bar-fill {
+  width: 40%;
+  height: 100%;
+  background-color: #4caf50;
+  animation: progress-indeterminate 1s infinite linear;
+}
+
+@keyframes progress-indeterminate {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ function normalizeInput(text: string): string {
 import DataTable from './components/DataTable'
 import ChartView from './components/ChartView'
 import HistoryList, { type HistoryItem } from './components/HistoryList'
+import ProgressBar from './components/ProgressBar'
 import { queryDatabase } from './api'
 import './App.css'
 
@@ -47,6 +48,12 @@ function App() {
           {loading ? 'Loading...' : 'Ask'}
         </button>
       </form>
+      {loading && (
+        <div className="loading">
+          <p>Rapor hazırlanıyor...</p>
+          <ProgressBar />
+        </div>
+      )}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {result && (
         <div className="results">

--- a/frontend/src/components/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar.tsx
@@ -1,0 +1,7 @@
+export default function ProgressBar() {
+  return (
+    <div className="progress-bar">
+      <div className="progress-bar-fill" />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show a progress bar while a query is running
- style the progress indicator
- document that a progress indicator appears during queries

## Testing
- `npm install`
- `npm run build`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_b_68755a5bcbcc832fba0ab42e509414a1