### PR TITLE
Add FastAPI backend for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ npm run dev
 ```
 This starts the development server on `http://localhost:5173`.
 
+### Running the backend API
+Start the FastAPI server which provides the `/api/query` endpoint used by the frontend:
+```bash
+python api_server.py
+```
+The server listens on `http://localhost:8000`.
+
+The Vite development server is configured to proxy `/api` requests to this backend, so the React app can communicate with it without additional configuration.
+
 ### API contract
 The frontend expects a backend endpoint `POST /api/query` with the following JSON payload:
 ```json

--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,56 @@
+import os
+import sqlite3
+import json
+import openai
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from dotenv import load_dotenv
+import nl2sql_app
+
+load_dotenv()
+api_key = os.getenv('OPENAI_API_KEY')
+model = os.getenv('OPENAI_MODEL', 'gpt-4-turbo')
+if not api_key:
+    raise RuntimeError('Please set the OPENAI_API_KEY environment variable.')
+openai.api_key = api_key
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=['*'],
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+conn = sqlite3.connect(nl2sql_app.DB_PATH)
+cursor = conn.cursor()
+schema = nl2sql_app.get_schema(cursor)
+
+class QueryRequest(BaseModel):
+    question: str
+
+@app.post('/api/query')
+def query_database(req: QueryRequest):
+    question = nl2sql_app.normalize_turkish_text(req.question)
+    try:
+        instruction = nl2sql_app.ask_llm(question, schema, model)
+        sql = instruction.get('sql')
+        chart_type = instruction.get('chart_type', 'table')
+        x = instruction.get('x')
+        y = instruction.get('y')
+        df = nl2sql_app.execute_sql(conn, sql)
+        data = df.to_dict(orient='records')
+        return {
+            'sql': sql,
+            'chart_type': chart_type,
+            'x': x,
+            'y': y,
+            'data': data,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
 })

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ seaborn
 openai
 python-dotenv
 Faker
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- create `api_server.py` with a `/api/query` endpoint
- update requirements to include FastAPI and Uvicorn
- proxy `/api` requests from Vite dev server to backend
- document backend server usage in README

## Testing
- `pip install -r requirements.txt`
- `python -m uvicorn api_server:app --port 8000` *(fails: OPENAI_API_KEY not set)*
- `npm install` and `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68755d817f04832f854c7f9e882fb5a0