### PR TITLE
Add SQL and chart debug logging

### DIFF
--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -47,6 +47,13 @@ export default function ChartView({ data, chartType, x, y }: Props) {
     ],
   }
 
+  // Log how chart data will be rendered
+  console.log('[CHART] labels:', labels)
+  console.log('[CHART] dataset data:', values)
+  // Example output:
+  // [CHART] labels: ['Ocak', 'Şubat', 'Mart']
+  // [CHART] dataset data: [120, 150, 90]
+
   if (chartType === 'bar') return <Bar data={chartData} />
   if (chartType === 'line') return <Line data={chartData} />
   if (chartType === 'scatter') {
@@ -58,6 +65,9 @@ export default function ChartView({ data, chartType, x, y }: Props) {
         },
       ],
     }
+    console.log('[CHART] scatter dataset:', scatterData.datasets[0].data)
+    // Example output:
+    // [CHART] scatter dataset: [{ x: 'Ocak', y: 120 }, { x: 'Şubat', y: 150 }]
     return <Scatter data={scatterData} />
   }
 

--- a/nl2sql_app.py
+++ b/nl2sql_app.py
@@ -59,6 +59,15 @@ def ask_llm(question, schema, model):
 
 def execute_sql(conn, sql):
     df = pd.read_sql_query(sql, conn)
+    # Log the SQL query and first 5 rows of the resulting dataframe
+    print("[SQL QUERY]", sql)
+    # Printing only the first 5 rows keeps the log concise
+    print(df.head())
+    # Example log:
+    # [SQL QUERY] SELECT * FROM Calisanlar LIMIT 10
+    #     id     isim  soyisim
+    # 0    1   Ahmet  Yilmaz
+    # 1    2  Mehmet  Kaya
     return df
 
 def display_result(df, chart_type, x=None, y=None):


### PR DESCRIPTION
## Summary
- log executed SQL and first 5 rows in the backend
- print chart labels and dataset values in the frontend before rendering

## Testing
- `pip install -r requirements.txt`
- `npm install`
- `npm run lint` *(fails: Unexpected any errors)*
- `python -m py_compile nl2sql_app.py api_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68756c3c47bc832fb09a5d14ff6239ee