### PR TITLE
Improve payload handling for /api/query

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,6 +13,8 @@ export interface QueryResponse {
 
 // Question should already be normalised before calling this function
 export async function queryDatabase(question: string): Promise<QueryResponse> {
+  // Debug log of the exact payload being sent
+  console.log('POST /api/query payload:', { question })
   const res = await fetch('/api/query', {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary
- validate incoming JSON payload in `api_server.py` and log it
- add early error for array payloads
- log payload before sending request from frontend

## Testing
- `python -m py_compile api_server.py`
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687575c2bb38832f9c253cd890358460