### PR TITLE
Fix space key issue in query input

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 
-// Normalise Turkish text by trimming whitespace and applying locale aware lower case
+// Normalise Turkish text by trimming whitespace and applying locale aware
+// lowercase. This is performed on submit only so the user can freely type
+// spaces while editing the query.
 function normalizeInput(text: string): string {
   return text.trim().replace(/\s+/g, ' ').toLocaleLowerCase('tr-TR')
 }
@@ -42,7 +44,7 @@ function App() {
       <form onSubmit={handleSubmit}>
         <textarea
           value={question}
-          onChange={(e) => setQuestion(normalizeInput(e.target.value))}
+          onChange={(e) => setQuestion(e.target.value)}
           placeholder="Enter your question in Turkish or English"
         />
         <button type="submit" disabled={loading || !question.trim()}>


### PR DESCRIPTION
## Summary
- prevent text normalisation on each keystroke
- update comment on normalisation function

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687581eaab9c832fba3ccb5321989f97