### PR TITLE
Fix API request body handling

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 import json
 import openai
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Body
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, ValidationError
 from typing import Any
@@ -72,7 +72,7 @@ class QueryRequest(BaseModel):
 
 
 @app.post("/api/query")
-def query_database(req: Any):
+def query_database(req: Any = Body(...)):
     # Log raw payload for debugging purposes
     print("[API] Received payload:", req)
     # Reject array payloads early with a clear message


### PR DESCRIPTION
## Summary
- parse POST payloads using `Body` so FastAPI reads the JSON body

## Testing
- `python -m py_compile nl2sql_app.py api_server.py create_demo_db.py`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687584afc3ac832f8f7ac63c0dfa4a78