### PR TITLE
Improve dashboard styling and chart display

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NL2SQL Demo</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <title>NL2SQL Analytics</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,10 +1,10 @@
 .app {
-  max-width: 800px;
-  margin: 0 auto;
+  max-width: 900px;
+  margin: 2rem auto;
   padding: 1rem;
 }
 
-form {
+.query-form {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -17,8 +17,17 @@ textarea {
   resize: vertical;
 }
 
-.results {
+
+.card {
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  padding: 1rem;
   margin-top: 1rem;
+}
+
+.results {
+  margin-top: 0;
 }
 
 .history {
@@ -27,9 +36,10 @@ textarea {
 
 .history-item {
   cursor: pointer;
-  border: 1px solid #ccc;
+  border: 1px solid #e5e7eb;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
+  border-radius: 4px;
 }
 
 .table-container {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,17 +40,19 @@ function App() {
 
   return (
     <div className="app">
-      <h1>Natural Language SQL Demo</h1>
-      <form onSubmit={handleSubmit}>
-        <textarea
-          value={question}
-          onChange={(e) => setQuestion(e.target.value)}
-          placeholder="Enter your question in Turkish or English"
-        />
-        <button type="submit" disabled={loading || !question.trim()}>
-          {loading ? 'Loading...' : 'Ask'}
-        </button>
-      </form>
+      <h1>Natural Language SQL</h1>
+      <div className="card">
+        <form onSubmit={handleSubmit} className="query-form">
+          <textarea
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            placeholder="Enter your question in Turkish or English"
+          />
+          <button type="submit" disabled={loading || !question.trim()}>
+            {loading ? 'Loading...' : 'Ask'}
+          </button>
+        </form>
+      </div>
       {loading && (
         <div className="loading">
           <p>Rapor hazırlanıyor...</p>
@@ -59,7 +61,7 @@ function App() {
       )}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {result && (
-        <div className="results">
+        <div className="card results">
           <h3>SQL</h3>
           <pre className="sql">{result.sql}</pre>
           {result.chart_type === 'table' ? (
@@ -74,7 +76,9 @@ function App() {
           )}
         </div>
       )}
-      <HistoryList items={history} onSelect={(item) => setResult(item)} />
+      <div className="card">
+        <HistoryList items={history} onSelect={(item) => setResult(item)} />
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -36,40 +36,44 @@ export default function ChartView({ data, chartType, x, y }: Props) {
   }
 
   const labels = data.map((d) => d[x])
-  const values = data.map((d) => d[y])
 
-  const chartData = {
-    labels,
-    datasets: [
-      {
-        label: y,
-        data: values,
-      },
-    ],
+  // Determine which columns to plot on the y axis. Handle comma separated
+  // lists or fallback to any numeric columns found in the result set.
+  let yKeys = Array.isArray(y) ? y : y.split(',').map((s) => s.trim())
+  if (!yKeys[0]) {
+    yKeys = Object.keys(data[0]).filter((k) => k !== x)
+  }
+  yKeys = yKeys.filter((k) => typeof data[0][k] === 'number')
+
+  const palette = ['#3b82f6', '#10b981', '#ef4444', '#f59e0b', '#6366f1']
+  const datasets = yKeys.map((key, idx) => ({
+    label: key,
+    data: data.map((d) => d[key]),
+    borderColor: palette[idx % palette.length],
+    backgroundColor: palette[idx % palette.length],
+    fill: false,
+  }))
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: { position: 'bottom' as const },
+      title: { display: true, text: yKeys.join(' vs ') },
+    },
   }
 
-  // Log how chart data will be rendered
-  console.log('Chart labels:', labels)
-  console.log('Chart values:', values)
-  // Example output:
-  // [CHART] labels: ['Ocak', 'Şubat', 'Mart']
-  // [CHART] dataset data: [120, 150, 90]
-
-  if (chartType === 'bar') return <Bar data={chartData} />
-  if (chartType === 'line') return <Line data={chartData} />
+  if (chartType === 'bar') return <Bar data={{ labels, datasets }} options={options} />
+  if (chartType === 'line') return <Line data={{ labels, datasets }} options={options} />
   if (chartType === 'scatter') {
     const scatterData = {
-      datasets: [
-        {
-          label: `${y} vs ${x}`,
-          data: data.map((d) => ({ x: d[x], y: d[y] })),
-        },
-      ],
+      datasets: yKeys.slice(0, 2).map((key, idx) => ({
+        label: key,
+        data: data.map((d) => ({ x: d[x], y: d[key] })),
+        borderColor: palette[idx % palette.length],
+        backgroundColor: palette[idx % palette.length],
+      })),
     }
-    console.log('[CHART] scatter dataset:', scatterData.datasets[0].data)
-    // Example output:
-    // [CHART] scatter dataset: [{ x: 'Ocak', y: 120 }, { x: 'Şubat', y: 150 }]
-    return <Scatter data={scatterData} />
+    return <Scatter data={scatterData} options={options} />
   }
 
   return null

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,11 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #333;
+  background-color: #f5f7fa;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -36,33 +34,34 @@ h1 {
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #3b82f6;
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: #2563eb;
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: 2px solid #2563eb;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: #d1d5db;
+    background-color: #1f2937;
   }
   a:hover {
-    color: #747bff;
+    color: #a5b4fc;
   }
   button {
-    background-color: #f9f9f9;
+    background-color: #374151;
   }
 }


### PR DESCRIPTION
## Summary
- modernize frontend styling with cards and responsive layout
- remove "Demo" from the title and headings
- enhance charts with multiple datasets, legend and title

## Testing
- `npm run lint`
- `python -m py_compile api_server.py nl2sql_app.py create_demo_db.py`


------
https://chatgpt.com/codex/tasks/task_b_68758ae09f0c832f8894a905a79d9fdf