### PR TITLE
Enable multi-modal query responses

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,16 +64,20 @@ function App() {
         <div className="card results">
           <h3>SQL</h3>
           <pre className="sql">{result.sql}</pre>
-          {result.chart_type === 'table' ? (
-            <DataTable data={result.data} />
-          ) : (
-            <ChartView
-              data={result.data}
-              chartType={result.chart_type}
-              x={result.x!}
-              y={result.y!}
-            />
-          )}
+          {result.visuals.map((vis, idx) => (
+            <div key={idx} className="visual-block">
+              {vis.type === 'table' ? (
+                <DataTable data={vis.data} />
+              ) : (
+                <ChartView
+                  data={vis.data}
+                  chartType={vis.type}
+                  x={vis.x!}
+                  y={vis.y!}
+                />
+              )}
+            </div>
+          ))}
         </div>
       )}
       <div className="card">

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,13 +2,17 @@ export interface QueryRequest {
   question: string
 }
 
-export interface QueryResponse {
-  sql: string
-  chart_type: 'table' | 'bar' | 'line' | 'scatter'
+export interface VisualSpec {
+  type: 'table' | 'bar' | 'line' | 'scatter'
   x?: string
   y?: string | string[]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any[]
+}
+
+export interface QueryResponse {
+  sql: string
+  visuals: VisualSpec[]
 }
 
 // Question should already be normalised before calling this function

--- a/frontend/src/components/HistoryList.tsx
+++ b/frontend/src/components/HistoryList.tsx
@@ -1,12 +1,10 @@
 
+import type { VisualSpec } from '../api'
+
 export interface HistoryItem {
   question: string
   sql: string
-  chart_type: 'table' | 'bar' | 'line' | 'scatter'
-  x?: string
-  y?: string | string[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any[]
+  visuals: VisualSpec[]
 }
 
 interface Props {


### PR DESCRIPTION
## Summary
- extend LLM prompt and parser for multi-series and multi-modal visualisations
- update backend API to return a `visuals` array
- support new response format in frontend
- document new API contract and give example prompts

## Testing
- `npm run build --silent`
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687611942948832fb8878e62e47f9003