### PR TITLE
Add schema explorer and context-aware queries

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,6 +4,49 @@
   padding: 1rem;
 }
 
+.layout {
+  display: flex;
+  gap: 1rem;
+}
+
+.main {
+  flex: 1;
+}
+
+.schema-explorer {
+  width: 250px;
+  flex-shrink: 0;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  padding: 0.5rem;
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.schema-explorer input {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.schema-explorer .table-block {
+  margin-bottom: 0.5rem;
+}
+
+.schema-explorer ul {
+  list-style: none;
+  padding-left: 0.5rem;
+}
+
+.column-item {
+  cursor: pointer;
+}
+
+.fk-ind {
+  color: #f59e0b;
+  margin-left: 0.25rem;
+}
+
 .query-form {
   display: flex;
   flex-direction: column;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,6 @@
 export interface QueryRequest {
   question: string
+  context?: string[]
 }
 
 export interface VisualSpec {
@@ -16,15 +17,15 @@ export interface QueryResponse {
 }
 
 // Question should already be normalised before calling this function
-export async function queryDatabase(question: string): Promise<QueryResponse> {
+export async function queryDatabase(question: string, context: string[] = []): Promise<QueryResponse> {
   // Debug log of the exact payload being sent
-  console.log('POST /api/query payload:', { question })
+  console.log('POST /api/query payload:', { question, context })
   const res = await fetch('/api/query', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ question }),
+    body: JSON.stringify({ question, context }),
   })
   if (!res.ok) {
     const text = await res.text()
@@ -34,4 +35,28 @@ export async function queryDatabase(question: string): Promise<QueryResponse> {
   // Debug log: inspect API response as soon as we receive it
   console.log('API response:', data)
   return data
+}
+
+export interface SchemaField {
+  name: string
+  type: string
+  fk?: { table: string; column: string }
+}
+
+export interface SchemaTable {
+  name: string
+  columns: SchemaField[]
+}
+
+export interface SchemaResponse {
+  tables: SchemaTable[]
+}
+
+export async function fetchSchema(): Promise<SchemaResponse> {
+  const res = await fetch('/api/schema')
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(text || 'API error')
+  }
+  return await res.json()
 }

--- a/frontend/src/components/SchemaExplorer.tsx
+++ b/frontend/src/components/SchemaExplorer.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import type { SchemaResponse, SchemaTable } from '../api'
+import { fetchSchema } from '../api'
+
+interface Props {
+  onSelect: (field: string) => void
+}
+
+export default function SchemaExplorer({ onSelect }: Props) {
+  const [schema, setSchema] = useState<SchemaTable[]>([])
+  const [filter, setFilter] = useState('')
+
+  useEffect(() => {
+    fetchSchema()
+      .then((data: SchemaResponse) => setSchema(data.tables))
+      .catch((err) => console.error(err))
+  }, [])
+
+  const filtered = schema.map((tbl) => ({
+    ...tbl,
+    columns: tbl.columns.filter((c) =>
+      (tbl.name + '.' + c.name).toLowerCase().includes(filter.toLowerCase())
+    ),
+  }))
+
+  return (
+    <div className="schema-explorer">
+      <h3>Schema Explorer</h3>
+      <input
+        type="text"
+        placeholder="Search"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+      />
+      <div className="schema-list">
+        {filtered.map((tbl) => (
+          <div key={tbl.name} className="table-block">
+            <strong>{tbl.name}</strong>
+            <ul>
+              {tbl.columns.map((col) => (
+                <li
+                  key={col.name}
+                  className="column-item"
+                  title={col.fk ? `FK -> ${col.fk.table}.${col.fk.column}` : ''}
+                  onClick={() => onSelect(`${tbl.name}.${col.name}`)}
+                >
+                  {col.name}
+                  {col.fk && <span className="fk-ind">*</span>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show DB schema details via new `/api/schema` endpoint
- add `context` to query payload so selected fields refine prompts
- implement `SchemaExplorer` component with search and FK markers
- update layout to display explorer next to query form

## Testing
- `npm run lint`
- `python -m py_compile api_server.py nl2sql_app.py`


------
https://chatgpt.com/codex/tasks/task_b_687614324194832f9d30adca9afaab8f