### PR TITLE
Fix demo DB path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist/
 venv/
 
 .env
+/demo_sirket.db

--- a/create_demo_db.py
+++ b/create_demo_db.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 from faker import Faker
 import random
@@ -5,7 +6,9 @@ from datetime import datetime, timedelta
 
 fake = Faker('tr_TR')
 
-conn = sqlite3.connect('demo_sirket.db')
+# Veritabanı dosyası script konumuna göre `Database/` klasörüne yazılır
+db_path = os.path.join(os.path.dirname(__file__), 'Database', 'demo_sirket.db')
+conn = sqlite3.connect(db_path)
 cur = conn.cursor()
 
 # Temel tabloları oluştur
@@ -276,4 +279,4 @@ for _ in range(8000):
 conn.commit()
 conn.close()
 
-print("Veritabanı başarıyla oluşturuldu: demo_sirket.db")
+print(f"Veritabanı başarıyla oluşturuldu: {db_path}")


### PR DESCRIPTION
## Summary
- update `create_demo_db.py` to always write the demo database inside the `Database/` directory
- ignore any accidental `demo_sirket.db` created at repo root

## Testing
- `python3 -m py_compile api_server.py create_demo_db.py nl2sql_app.py`


------
https://chatgpt.com/codex/tasks/task_b_68761af148d8832f8c7de67dd386348b