### PR TITLE
Update README with schema endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ npm run dev
 This starts the development server on `http://localhost:5173`.
 
 ### Running the backend API
-Start the FastAPI server which provides the `/api/query` endpoint used by the frontend:
+Start the FastAPI server which provides the `/api/query` endpoint used by the frontend and exposes `GET /api/schema` for schema information:
 ```bash
 python api_server.py
 ```
-The server listens on `http://localhost:8000`.
+The server listens on `http://localhost:8000`. Ensure that both `/api/query` and `/api/schema` are reachable when running the React frontend.
 
 The Vite development server is configured to proxy `/api` requests to this backend, so the React app can communicate with it without additional configuration.
 


### PR DESCRIPTION
## Summary
- document GET /api/schema in backend instructions
- remind that both /api/query and /api/schema must be reachable for the React frontend

## Testing
- `pip install -r requirements.txt`
- `npm install && npm run lint`
- `python -m py_compile api_server.py create_demo_db.py nl2sql_app.py`

------
https://chatgpt.com/codex/tasks/task_b_68761c20e0c8832fa643254fe2b76641