### PR TITLE
Add schema endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,26 @@ Start the FastAPI server which provides the `/api/query` endpoint used by the fr
 ```bash
 python api_server.py
 ```
-The server listens on `http://localhost:8000`. Ensure that both `/api/query` and `/api/schema` are reachable when running the React frontend.
+The server listens on `http://localhost:8000`. Ensure that both `/api/query` and
+`/api/schema` are reachable when running the React frontend.
+
+`GET /api/schema` returns a simple mapping of tables and columns:
+
+```json
+{
+  "Calisanlar": [
+    {"name": "id", "type": "INTEGER"},
+    {"name": "isim", "type": "TEXT"}
+  ],
+  "Satislar": [
+    {"name": "id", "type": "INTEGER"},
+    {"name": "tarih", "type": "DATE"}
+  ]
+}
+```
+
+For more detailed information including foreign keys you can call
+`GET /api/schema/details`.
 
 The Vite development server is configured to proxy `/api` requests to this backend, so the React app can communicate with it without additional configuration.
 

--- a/api_server.py
+++ b/api_server.py
@@ -65,6 +65,13 @@ with sqlite3.connect(nl2sql_app.DB_PATH) as _conn:
     _cursor = _conn.cursor()
     schema = nl2sql_app.get_schema(_cursor)
     schema_details = nl2sql_app.get_schema_details(_cursor)
+    # Build a simple mapping of table -> columns for the /api/schema endpoint
+    schema_overview = {}
+    for table in schema_details["tables"]:
+        schema_overview[table["name"]] = [
+            {"name": col["name"], "type": col["type"]}
+            for col in table["columns"]
+        ]
 
 
 class QueryRequest(BaseModel):
@@ -112,8 +119,14 @@ async def query_database(req: QueryRequest = Body(...)):
 
 
 @app.get("/api/schema")
+async def get_schema_endpoint():
+    """Return a simple mapping of table names to column info."""
+    return schema_overview
+
+
+@app.get("/api/schema/details")
 async def get_schema_details_endpoint():
-    """Return cached schema details for the frontend schema explorer."""
+    """Return full schema details including foreign keys."""
     return schema_details
 
 


### PR DESCRIPTION
## Summary
- add simple schema listing to API server
- provide detailed schema info via `/api/schema/details`
- document new endpoints in README

## Testing
- `python -m py_compile api_server.py nl2sql_app.py create_demo_db.py`
- `OPENAI_API_KEY=dummy python api_server.py &` *(checked `/api/schema` and `/api/schema/details`)*

------
https://chatgpt.com/codex/tasks/task_b_68761e379f0c832f9ebbfdee269222ce