### PR TITLE
Fix SchemaExplorer null safety and add error boundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h2>Something went wrong.</h2>
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/components/SchemaExplorer.tsx
+++ b/frontend/src/components/SchemaExplorer.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export default function SchemaExplorer({ onSelect }: Props) {
-  const [schema, setSchema] = useState<SchemaTable[]>([])
+  const [schema, setSchema] = useState<SchemaTable[] | null>(null)
   const [filter, setFilter] = useState('')
 
   useEffect(() => {
@@ -16,9 +16,13 @@ export default function SchemaExplorer({ onSelect }: Props) {
       .catch((err) => console.error(err))
   }, [])
 
+  if (!schema) {
+    return <div>Loading schema...</div>
+  }
+
   const filtered = schema.map((tbl) => ({
     ...tbl,
-    columns: tbl.columns.filter((c) =>
+    columns: (tbl.columns ?? []).filter((c) =>
       (tbl.name + '.' + c.name).toLowerCase().includes(filter.toLowerCase())
     ),
   }))
@@ -37,7 +41,7 @@ export default function SchemaExplorer({ onSelect }: Props) {
           <div key={tbl.name} className="table-block">
             <strong>{tbl.name}</strong>
             <ul>
-              {tbl.columns.map((col) => (
+              {(tbl.columns ?? []).map((col) => (
                 <li
                   key={col.name}
                   className="column-item"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import ErrorBoundary from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- avoid `.map` on potentially undefined values in `SchemaExplorer`
- show loading state until schema fetch completes
- wrap app in an error boundary to surface any render errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687621899030832fb16c0a84afa55274