### PR TITLE
Remove SQL output from UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -100,11 +100,6 @@ th, td {
   text-align: left;
 }
 
-pre.sql {
-  white-space: pre-wrap;
-  background: #f7f7f7;
-  padding: 0.5rem;
-}
 
 .loading {
   margin-top: 1rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,8 +71,6 @@ function App() {
           {error && <p style={{ color: 'red' }}>{error}</p>}
           {result && (
             <div className="card results">
-              <h3>SQL</h3>
-              <pre className="sql">{result.sql}</pre>
               {result.visuals.map((vis, idx) => (
                 <div key={idx} className="visual-block">
                   {vis.type === 'table' ? (

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, ErrorInfo, ReactNode } from 'react'
+import { Component, type ErrorInfo, type ReactNode } from 'react'
 
 interface Props {
   children: ReactNode

--- a/frontend/src/components/HistoryList.tsx
+++ b/frontend/src/components/HistoryList.tsx
@@ -20,7 +20,6 @@ export default function HistoryList({ items, onSelect }: Props) {
       {items.map((it, idx) => (
         <div key={idx} className="history-item" onClick={() => onSelect(it)}>
           <p className="question">{it.question}</p>
-          <pre className="sql">{it.sql}</pre>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- stop displaying SQL results in the main viewer
- stop showing SQL in history list
- drop unused CSS for SQL blocks
- fix ErrorBoundary import for TypeScript build

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6876397b92bc832fa01fbeed2272638e