### PR TITLE
Add friendly labels to schema overview

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -72,12 +72,21 @@ with sqlite3.connect(nl2sql_app.DB_PATH) as _conn:
     # more detailed /api/schema/details endpoint.
     schema_overview = {"tables": []}
     for table in schema_details["tables"]:
-        friendly_table = TECH_TO_FRIENDLY.get(table["name"], table["name"])
-        columns = [
-            {"name": TECH_TO_FRIENDLY.get(col["name"], col["name"]), "type": col["type"]}
-            for col in table["columns"]
-        ]
-        schema_overview["tables"].append({"name": friendly_table, "columns": columns})
+        table_entry = {"name": table["name"], "columns": []}
+        tbl_label = TECH_TO_FRIENDLY.get(table["name"])
+        if tbl_label and tbl_label != table["name"]:
+            table_entry["friendly"] = tbl_label
+
+        for col in table["columns"]:
+            col_entry = {"name": col["name"], "type": col["type"]}
+            if "fk" in col:
+                col_entry["fk"] = col["fk"]
+            col_label = TECH_TO_FRIENDLY.get(col["name"])
+            if col_label and col_label != col["name"]:
+                col_entry["friendly"] = col_label
+            table_entry["columns"].append(col_entry)
+
+        schema_overview["tables"].append(table_entry)
 
 
 class QueryRequest(BaseModel):

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -40,11 +40,13 @@ export async function queryDatabase(question: string, context: string[] = []): P
 export interface SchemaField {
   name: string
   type: string
+  friendly?: string
   fk?: { table: string; column: string }
 }
 
 export interface SchemaTable {
   name: string
+  friendly?: string
   columns: SchemaField[]
 }
 

--- a/frontend/src/components/SchemaExplorer.tsx
+++ b/frontend/src/components/SchemaExplorer.tsx
@@ -30,12 +30,18 @@ export default function SchemaExplorer({ onSelect }: Props) {
     return null
   }
 
-  const filtered = schema.map((tbl) => ({
-    ...tbl,
-    columns: (tbl.columns ?? []).filter((c) =>
-      (tbl.name + '.' + c.name).toLowerCase().includes(filter.toLowerCase())
-    ),
-  }))
+  const filtered = schema.map((tbl) => {
+    const tblLabel = tbl.friendly ?? tbl.name
+    return {
+      ...tbl,
+      columns: (tbl.columns ?? []).filter((c) => {
+        const searchTarget = (
+          tblLabel + '.' + (c.friendly ?? c.name)
+        ).toLowerCase()
+        return searchTarget.includes(filter.toLowerCase())
+      }),
+    }
+  })
 
   return (
     <div className="schema-explorer">
@@ -49,7 +55,7 @@ export default function SchemaExplorer({ onSelect }: Props) {
       <div className="schema-list">
         {filtered.map((tbl) => (
           <div key={tbl.name} className="table-block">
-            <strong>{tbl.name}</strong>
+            <strong>{tbl.friendly ?? tbl.name}</strong>
             <ul>
               {(tbl.columns ?? []).map((col) => (
                 <li
@@ -58,7 +64,7 @@ export default function SchemaExplorer({ onSelect }: Props) {
                   title={col.fk ? `FK -> ${col.fk.table}.${col.fk.column}` : ''}
                   onClick={() => onSelect(`${tbl.name}.${col.name}`)}
                 >
-                  {col.name}
+                  {col.friendly ?? col.name}
                   {col.fk && <span className="fk-ind">*</span>}
                 </li>
               ))}


### PR DESCRIPTION
## Summary
- include technical name and optional friendly label in `/api/schema` output
- expose new fields in client API types
- show friendly names in Schema Explorer but send technical identifiers on click

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile api_server.py nl2sql_app.py field_mapping.py`


------
https://chatgpt.com/codex/tasks/task_b_68763c0bc058832f9fd202d1c951cd4f