### PR TITLE
Hide sqlite_sequence from schema

### DIFF
--- a/nl2sql_app.py
+++ b/nl2sql_app.py
@@ -47,7 +47,9 @@ def get_schema(cursor):
     global SCHEMA_CACHE
     if SCHEMA_CACHE is not None:
         return SCHEMA_CACHE
-    tables = cursor.execute("SELECT name FROM sqlite_master WHERE type='table';").fetchall()
+    tables = cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+    ).fetchall()
     schema_lines = []
     for (tbl,) in tables:
         cols = cursor.execute(f'PRAGMA table_info({tbl});').fetchall()
@@ -62,7 +64,9 @@ def get_schema_details(cursor):
     global SCHEMA_DETAILS_CACHE
     if SCHEMA_DETAILS_CACHE is not None:
         return SCHEMA_DETAILS_CACHE
-    tables = cursor.execute("SELECT name FROM sqlite_master WHERE type='table';").fetchall()
+    tables = cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+    ).fetchall()
     result = {"tables": []}
     for (tbl,) in tables:
         cols = cursor.execute(f'PRAGMA table_info({tbl});').fetchall()


### PR DESCRIPTION
## Summary
- skip SQLite internal tables when constructing schema details

## Testing
- `python -m py_compile api_server.py nl2sql_app.py field_mapping.py`
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68764ad77504832fb0caa823963482e3