### PR TITLE
Add locale-aware number formatting

### DIFF
--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -37,6 +37,19 @@ export default function ChartView({ data, chartType, x, y }: Props) {
 
   const labels = data.map((d) => d[x])
 
+  // Access potential unit fields if present in the first row
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const unitSource = data[0] as any
+  const unit =
+    unitSource.birim ||
+    unitSource.para_birim ||
+    unitSource.currency ||
+    unitSource.doviz
+  const numberFormatter = new Intl.NumberFormat('tr-TR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+
   // Determine which columns to plot on the y axis. Handle comma separated
   // lists or fallback to any numeric columns found in the result set.
   let yKeys = Array.isArray(y) ? y : y.split(',').map((s) => s.trim())
@@ -59,6 +72,24 @@ export default function ChartView({ data, chartType, x, y }: Props) {
     plugins: {
       legend: { position: 'bottom' as const },
       title: { display: true, text: yKeys.join(' vs ') },
+      tooltip: {
+        callbacks: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          label: (ctx: any) => {
+            const value = ctx.parsed.y ?? ctx.parsed
+            const formatted = numberFormatter.format(value)
+            return `${ctx.dataset.label || ''}: ${formatted}${unit ? ' ' + unit : ''}`
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        ticks: {
+          callback: (val: string | number) =>
+            numberFormatter.format(Number(val)) + (unit ? ' ' + unit : ''),
+        },
+      },
     },
   }
 

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -11,6 +11,25 @@ export default function DataTable({ data }: Props) {
 
   const headers = Object.keys(data[0])
 
+  // Format numbers using Turkish locale and append unit if present.
+  const formatValue = (val: unknown, row: Record<string, unknown>) => {
+    if (typeof val === 'number') {
+      const formatted = val.toLocaleString('tr-TR', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rowAny = row as any
+      const unit =
+        rowAny.birim ||
+        rowAny.para_birim ||
+        rowAny.currency ||
+        rowAny.doviz
+      return unit ? `${formatted} ${unit}` : formatted
+    }
+    return String(val)
+  }
+
   return (
     <div className="table-container">
       <table>
@@ -25,7 +44,7 @@ export default function DataTable({ data }: Props) {
           {data.map((row, idx) => (
             <tr key={idx}>
               {headers.map((h) => (
-                <td key={h}>{String(row[h])}</td>
+                <td key={h}>{formatValue(row[h], row)}</td>
               ))}
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- show numeric values using Turkish locale in DataTable
- display formatted axis ticks and tooltips in ChartView

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68764eceba28832fb1d7981dfac13502