### PR TITLE
Enhance UI styling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -83,6 +83,11 @@ textarea {
   padding: 0.5rem;
   margin-bottom: 0.5rem;
   border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.history-item:hover {
+  background-color: #f3f4f6;
 }
 
 .table-container {
@@ -127,7 +132,7 @@ th, td {
 .progress-bar-fill {
   width: 40%;
   height: 100%;
-  background-color: #4caf50;
+  background-image: linear-gradient(90deg, #3b82f6, #10b981);
   animation: progress-indeterminate 1s infinite linear;
 }
 
@@ -137,5 +142,35 @@ th, td {
   }
   to {
     transform: translateX(100%);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .card {
+    background: #1f2937;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  }
+  .schema-explorer {
+    background: #374151;
+    color: #f3f4f6;
+  }
+  .history-item {
+    border-color: #4b5563;
+  }
+  .history-item:hover {
+    background-color: #374151;
+  }
+  table {
+    color: inherit;
+  }
+  th,
+  td {
+    border-color: #4b5563;
+  }
+  .progress-bar {
+    background: #374151;
+  }
+  .progress-bar-fill {
+    background-image: linear-gradient(90deg, #2563eb, #059669);
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,7 +3,7 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light;
+  color-scheme: light dark;
   color: #333;
   background-color: #f5f7fa;
 
@@ -35,18 +35,18 @@ h1 {
 
 button {
   border-radius: 6px;
-  border: 1px solid #d1d5db;
+  border: none;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #3b82f6;
+  background-image: linear-gradient(90deg, #3b82f6, #10b981);
   color: #fff;
   cursor: pointer;
   transition: background-color 0.25s;
 }
 button:hover {
-  background-color: #2563eb;
+  filter: brightness(1.1);
 }
 button:focus,
 button:focus-visible {
@@ -62,6 +62,7 @@ button:focus-visible {
     color: #a5b4fc;
   }
   button {
+    background-image: none;
     background-color: #374151;
   }
 }


### PR DESCRIPTION
## Summary
- improve history item hover style
- add gradient fill to progress bar
- support dark mode across cards and other components
- polish primary button visuals
- enable color-scheme for dark mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6877fb919650832fa2fa664f6c55e205