### PR TITLE
Add heroicons and customer icon feature

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "chart.js": "^4.4.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
@@ -934,6 +935,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "chart.js": "^4.4.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,4 +1,6 @@
 
+import { UserIcon } from '@heroicons/react/20/solid'
+
 interface Props {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any[]
@@ -10,6 +12,15 @@ export default function DataTable({ data }: Props) {
   }
 
   const headers = Object.keys(data[0])
+
+  const customerHeaders = [
+    'müşteriler',
+    'müşteri',
+    'musteriler',
+    'musteri',
+    'customer',
+    'customers',
+  ]
 
   // Format numbers using Turkish locale and append unit if present.
   const formatValue = (val: unknown, row: Record<string, unknown>) => {
@@ -69,12 +80,21 @@ export default function DataTable({ data }: Props) {
                     ? 'text-green-600'
                     : ''
 
+                const isCustomerField = customerHeaders.some((ch) =>
+                  h.toLowerCase().includes(ch)
+                )
+
                 return (
                   <td
                     key={h}
                     className={`px-2 py-1 border border-gray-300 dark:border-gray-600 ${colorClass}`}
                   >
-                    {formatValue(val, row)}
+                    <div className="flex items-center gap-1">
+                      {isCustomerField && (
+                        <UserIcon className="w-4 h-4 text-gray-500" />
+                      )}
+                      {formatValue(val, row)}
+                    </div>
                   </td>
                 )
               })}


### PR DESCRIPTION
## Summary
- import heroicons icon set in frontend
- detect customer fields in `DataTable` and prepend a user icon

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68780484f140832f97a199a5a3da76bd