### PR TITLE
Add accessible spinner for loading state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ function normalizeInput(text: string): string {
 import DataTable from './components/DataTable'
 import ChartView from './components/ChartView'
 import HistoryList, { type HistoryItem } from './components/HistoryList'
-import ProgressBar from './components/ProgressBar'
+import Spinner from './components/Spinner'
 import { queryDatabase, type VisualSpec } from './api'
 import SchemaExplorer from './components/SchemaExplorer'
 import './App.css'
@@ -68,9 +68,8 @@ function App() {
             </form>
           </div>
           {loading && (
-            <div className="flex flex-col items-center gap-2">
-              <p>Rapor hazırlanıyor...</p>
-              <ProgressBar />
+            <div className="flex justify-center py-4">
+              <Spinner />
             </div>
           )}
           {error && <p className="text-red-500">{error}</p>}

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,0 +1,28 @@
+export default function Spinner() {
+  return (
+    <div role="status" className="flex items-center justify-center">
+      <svg
+        className="w-8 h-8 animate-spin text-primary"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4z"
+        />
+      </svg>
+      <span className="sr-only">Loading...</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `Spinner` component using Tailwind's `animate-spin`
- show `Spinner` in `App.tsx` instead of progress bar during loading

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687808563510832f8e34af12b44b9808