### PR TITLE
Add custom favicon and logo

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,10 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta property="og:image" content="/logo.svg" />
+    <meta name="description" content="Query the demo database using natural language and visualise the results." />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <title>NL2SQL Analytics</title>
+    <title>Visualise DB - NL2SQL Analytics</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="15" ry="15" fill="#4F46E5"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Arial" fill="white">V</text>
+</svg>

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 80">
+  <rect width="300" height="80" rx="10" fill="#4F46E5"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" font-family="Arial" fill="white">Visualise DB</text>
+</svg>


### PR DESCRIPTION
## Summary
- add custom favicon and logo assets
- reference favicon/logo in `index.html`
- set title and description meta tags

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68780991105c832fb4c6e7cbddb65d92