### PR TITLE
Fix Material Tailwind configuration

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { ThemeProvider } from '@material-tailwind/react'
 import './index.css'
 import ProDashboard from './ProDashboard.jsx'
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ProDashboard />
+    <ThemeProvider>
+      <ProDashboard />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,8 +1,9 @@
+import withMT from '@material-tailwind/react/utils/withMT'
 import type { Config } from 'tailwindcss'
 
-const config: Config = {
+const config: Config = withMT({
   mode: 'jit',
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],
   theme: {
     extend: {
       colors: {
@@ -20,5 +21,6 @@ const config: Config = {
     },
   },
   plugins: [],
-}
+})
+
 export default config


### PR DESCRIPTION
## Summary
- integrate Material Tailwind plugin with TailwindCSS
- wrap the React app in `ThemeProvider`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68784aa6a130832f83853d2f1208bc8a