### PR TITLE
Refactor frontend layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,21 @@
 import React, { useState } from 'react'
+import {
+  Card as MTCard,
+  CardBody as MTCardBody,
+  CardHeader as MTCardHeader,
+  Typography as MTTypography,
+  Textarea as MTTextarea,
+  Button as MTButton,
+} from '@material-tailwind/react'
+
+// Cast Material Tailwind components to loosely typed versions to avoid
+// excessive generic requirements in TypeScript.
+const Card = MTCard as any
+const CardBody = MTCardBody as any
+const CardHeader = MTCardHeader as any
+const Typography = MTTypography as any
+const Textarea = MTTextarea as any
+const Button = MTButton as any
 
 // Normalise Turkish text by trimming whitespace and applying locale aware
 // lowercase. This is performed on submit only so the user can freely type
@@ -46,125 +63,130 @@ function App() {
   }
 
   return (
-    <div className="min-h-screen p-4 space-y-4">
-      <h1 className="text-2xl font-bold text-center">Natural Language SQL</h1>
-      <div className="mx-auto grid max-w-7xl gap-4 lg:grid-cols-[18rem_1fr_18rem]">
-        <div className="lg:row-span-2 order-last lg:order-none">
-          <SchemaExplorer onSelect={handleFieldSelect} />
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
-          <h3 className="font-semibold mb-2">Query</h3>
-          <div className="space-y-4">
-            <form onSubmit={handleSubmit} className="space-y-2">
-              <textarea
-                value={question}
-                onChange={(e) => setQuestion(e.target.value)}
-                placeholder="Enter your question"
-                className="w-full min-h-[80px] resize-y rounded border border-gray-300 dark:border-gray-600 p-2"
-              />
-              <button
-                type="submit"
-                disabled={loading || !question.trim()}
-                className="w-32 rounded bg-blue-500 text-white px-4 py-2 disabled:opacity-50"
-              >
-                {loading ? 'Loading...' : 'Ask'}
-              </button>
-            </form>
-            {loading && (
-              <div className="flex justify-center py-2">
-                <Spinner />
-              </div>
-            )}
-            {error && <p className="text-red-500">{error}</p>}
-          </div>
-        </div>
-        {result && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 lg:col-start-2 lg:row-start-2">
-            <h3 className="font-semibold mb-2">Results</h3>
-            <div className="space-y-4">
-              {(() => {
-                const tableVis = result.visuals.find((v) => v.type === 'table')
-                const chartVis = result.visuals.find((v) => v.type !== 'table')
-                const remaining = result.visuals.filter(
-                  (v) => v !== tableVis && v !== chartVis
-                )
+    <div className="min-h-screen p-4">
+      <Typography variant="h4" className="mb-4 text-center">
+        Visualise DB
+      </Typography>
+      <div className="mx-auto grid max-w-7xl gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <CardHeader shadow={false} floated={false} className="p-4">
+            <Typography variant="h6">Schema Explorer</Typography>
+          </CardHeader>
+          <CardBody className="space-y-2">
+            <SchemaExplorer onSelect={handleFieldSelect} />
+          </CardBody>
+        </Card>
 
-                const getTitle = (vis: VisualSpec | undefined) => {
-                  if (!vis || vis.type === 'table') return ''
-                  const yKeys = Array.isArray(vis.y)
-                    ? vis.y
-                    : (vis.y ?? '').split(',').map((s) => s.trim())
-                  return vis.x && yKeys.length
-                    ? `${yKeys.join(', ')} vs ${vis.x}`
-                    : ''
-                }
+        <div className="flex flex-col space-y-4">
+          <Card>
+            <CardHeader shadow={false} floated={false} className="p-4">
+              <Typography variant="h6">Query</Typography>
+            </CardHeader>
+            <CardBody className="space-y-4">
+              <form onSubmit={handleSubmit} className="space-y-2">
+                <Textarea
+                  label="Sorunuzu yazın"
+                  className="min-h-[100px]"
+                  value={question}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                    setQuestion(e.target.value)
+                  }
+                />
+                <Button
+                  type="submit"
+                  color="blue"
+                  className="w-32"
+                  disabled={loading || !question.trim()}
+                >
+                  {loading ? 'Çalışıyor...' : 'Çalıştır'}
+                </Button>
+              </form>
+              {error && <Typography color="red">{error}</Typography>}
+              {loading && (
+                <div className="flex justify-center py-2">
+                  <Spinner />
+                </div>
+              )}
+            </CardBody>
+          </Card>
 
-                const cards: React.ReactNode[] = []
-
-                if (tableVis && chartVis) {
-                  cards.push(
-                    <div
-                      key="combo"
-                      className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 space-y-2"
-                    >
-                      <div>
-                        {getTitle(chartVis) && (
-                          <h3 className="font-semibold mb-1">{getTitle(chartVis)}</h3>
-                        )}
-                        <p className="text-xs text-gray-500 break-all font-mono">
-                          {result.sql}
-                        </p>
-                      </div>
-                      <div className="grid gap-4 md:grid-cols-2">
-                        <ChartView
-                          data={chartVis.data}
-                          chartType={chartVis.type as 'bar' | 'line' | 'scatter'}
-                          x={chartVis.x!}
-                          y={chartVis.y!}
-                        />
-                        <DataTable data={tableVis.data} />
-                      </div>
-                    </div>
+          {result && (
+            <Card>
+              <CardHeader shadow={false} floated={false} className="p-4">
+                <Typography variant="h6">Results</Typography>
+              </CardHeader>
+              <CardBody className="space-y-4">
+                {(() => {
+                  const tableVis = result.visuals.find((v) => v.type === 'table')
+                  const chartVis = result.visuals.find((v) => v.type !== 'table')
+                  const remaining = result.visuals.filter(
+                    (v) => v !== tableVis && v !== chartVis
                   )
-                }
 
-                cards.push(
-                  ...remaining.map((vis, idx) => (
-                    <div
-                      key={idx}
-                      className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 space-y-2"
-                    >
-                      {vis.type !== 'table' && getTitle(vis) && (
-                        <h3 className="font-semibold mb-1">{getTitle(vis)}</h3>
-                      )}
-                      <p className="text-xs text-gray-500 break-all font-mono">
-                        {result.sql}
-                      </p>
-                      {vis.type === 'table' ? (
-                        <DataTable data={vis.data} />
-                      ) : (
-                        <ChartView
-                          data={vis.data}
-                          chartType={vis.type as 'bar' | 'line' | 'scatter'}
-                          x={vis.x!}
-                          y={vis.y!}
-                        />
-                      )}
-                    </div>
-                  ))
-                )
+                  const getTitle = (vis: VisualSpec | undefined) => {
+                    if (!vis || vis.type === 'table') return ''
+                    const yKeys = Array.isArray(vis.y)
+                      ? vis.y
+                      : (vis.y ?? '').split(',').map((s) => s.trim())
+                    return vis.x && yKeys.length
+                      ? `${yKeys.join(', ')} vs ${vis.x}`
+                      : ''
+                  }
 
-                return cards
-              })()}
-            </div>
-          </div>
-        )}
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 lg:row-span-2 order-last lg:order-none">
-          <h3 className="font-semibold mb-2">History</h3>
-          <div className="space-y-2">
-            <HistoryList items={history} onSelect={(item) => setResult(item)} />
-          </div>
+                  const cards: React.ReactNode[] = []
+
+                  if (tableVis && chartVis) {
+                    cards.push(
+                      <div key="combo" className="space-y-2">
+                        <div>
+                          {getTitle(chartVis) && (
+                            <Typography variant="h6">{getTitle(chartVis)}</Typography>
+                          )}
+                          <Typography variant="small" className="break-all font-mono">
+                            {result.sql}
+                          </Typography>
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                          <ChartView data={chartVis.data} chartType={chartVis.type as 'bar' | 'line' | 'scatter'} x={chartVis.x!} y={chartVis.y!} />
+                          <DataTable data={tableVis.data} />
+                        </div>
+                      </div>
+                    )
+                  }
+
+                  cards.push(
+                    ...remaining.map((vis, idx) => (
+                      <div key={idx} className="space-y-2">
+                        {vis.type !== 'table' && getTitle(vis) && (
+                          <Typography variant="h6">{getTitle(vis)}</Typography>
+                        )}
+                        <Typography variant="small" className="break-all font-mono">
+                          {result.sql}
+                        </Typography>
+                        {vis.type === 'table' ? (
+                          <DataTable data={vis.data} />
+                        ) : (
+                          <ChartView data={vis.data} chartType={vis.type as 'bar' | 'line' | 'scatter'} x={vis.x!} y={vis.y!} />
+                        )}
+                      </div>
+                    ))
+                  )
+
+                  return cards
+                })()}
+              </CardBody>
+            </Card>
+          )}
         </div>
+
+        <Card className="md:col-span-2 lg:col-span-1">
+          <CardHeader shadow={false} floated={false} className="p-4">
+            <Typography variant="h6">History</Typography>
+          </CardHeader>
+          <CardBody className="space-y-2">
+            <HistoryList items={history} onSelect={(item) => setResult(item)} />
+          </CardBody>
+        </Card>
       </div>
     </div>
   )

--- a/frontend/src/components/SchemaExplorer.tsx
+++ b/frontend/src/components/SchemaExplorer.tsx
@@ -44,7 +44,7 @@ export default function SchemaExplorer({ onSelect }: Props) {
   })
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-2 overflow-y-auto max-h-[80vh] w-full lg:w-64 shrink-0">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-2 overflow-y-auto max-h-[80vh] w-full">
       <h3 className="font-semibold mb-2 text-lg">Schema Explorer</h3>
       <input
         type="text"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,12 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ThemeProvider } from '@material-tailwind/react'
 import './index.css'
-import ProDashboard from './ProDashboard.jsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
-      <ProDashboard />
+      <App />
     </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- refactor App to use Material Tailwind components
- rework layout into responsive 3‑column grid
- simplify SchemaExplorer width
- update main entry to render new App

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6878c48cf638832f858a61cc42a68337