### PR TITLE
Add custom UI components and theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,7 @@
 import React, { useState } from 'react'
-import {
-  Avatar as MTAvatar,
-  Button as MTButton,
-  Card as MTCard,
-  CardBody as MTCardBody,
-  Textarea as MTTextarea,
-  Typography as MTTypography,
-} from '@material-tailwind/react'
-
-const Avatar = MTAvatar as any
-const Button = MTButton as any
-const Card = MTCard as any
-const CardBody = MTCardBody as any
-const Textarea = MTTextarea as any
-const Typography = MTTypography as any
+import Button from './components/ui/Button'
+import Card from './components/ui/Card'
+import { Textarea } from './components/ui/Input'
 import DataTable from './components/DataTable'
 import ChartView from './components/ChartView'
 import SchemaExplorer from './components/SchemaExplorer'
@@ -57,10 +45,8 @@ export default function App() {
     <div className="min-h-screen flex flex-col">
       <header className="bg-gray-100">
         <div className="max-w-7xl mx-auto flex items-center justify-between p-4">
-          <Typography variant="h4" className="font-bold">
-            Visual DataBase
-          </Typography>
-          <Avatar variant="circular" className="bg-gray-300 w-8 h-8" />
+          <h1 className="text-2xl font-bold">Visual DataBase</h1>
+          <div className="w-8 h-8 rounded-full bg-gray-300" />
         </div>
       </header>
       <main className="flex-1 max-w-7xl mx-auto p-6">
@@ -68,7 +54,7 @@ export default function App() {
           <div className="col-span-4 lg:col-span-3 flex flex-col space-y-6">
             <form onSubmit={handleSubmit} className="space-y-4">
               <Textarea
-                label="Sorunuzu yazın"
+                placeholder="Sorunuzu yazın"
                 className="min-h-[120px]"
                 value={question}
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
@@ -77,14 +63,13 @@ export default function App() {
               />
               <Button
                 type="submit"
-                color="blue"
                 className="w-full text-base"
                 disabled={loading || !question.trim()}
               >
                 {loading ? 'Çalışıyor...' : 'ASK'}
               </Button>
             </form>
-            {error && <Typography color="red">{error}</Typography>}
+            {error && <p className="text-red-600">{error}</p>}
             {loading && (
               <div className="flex justify-center py-4">
                 <Spinner />
@@ -94,16 +79,14 @@ export default function App() {
               <div className="space-y-6">
                 {result.map((vis, idx) => (
                   <Card key={idx}>
-                    <CardBody className="space-y-4">
+                    <div className="p-4 space-y-4">
                       {vis.type !== 'table' && vis.x && vis.y && (
-                        <Typography variant="h6">
+                        <h2 className="text-lg font-semibold">
                           {Array.isArray(vis.y) ? vis.y.join(', ') : vis.y} vs {vis.x}
-                        </Typography>
+                        </h2>
                       )}
                       {sql && (
-                        <Typography variant="small" className="break-all font-mono">
-                          {sql}
-                        </Typography>
+                        <p className="text-sm break-all font-mono">{sql}</p>
                       )}
                       {vis.type === 'table' ? (
                         <DataTable data={vis.data} />
@@ -115,7 +98,7 @@ export default function App() {
                           y={vis.y!}
                         />
                       )}
-                    </CardBody>
+                    </div>
                   </Card>
                 ))}
               </div>
@@ -123,10 +106,10 @@ export default function App() {
           </div>
           <div className="col-span-4 lg:col-span-1">
             <Card className="shadow">
-              <CardBody className="space-y-2">
-                <Typography variant="h6">Schema Explorer</Typography>
+              <div className="p-2 space-y-2">
+                <h2 className="text-lg font-semibold">Schema Explorer</h2>
                 <SchemaExplorer onSelect={handleFieldSelect} />
-              </CardBody>
+              </div>
             </Card>
           </div>
         </div>

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary'
+}
+
+export default function Button({
+  variant = 'primary',
+  className = '',
+  disabled,
+  ...props
+}: ButtonProps) {
+  const base =
+    'px-4 py-2 rounded font-medium focus:outline-none transition-colors'
+  const variants: Record<string, string> = {
+    primary: 'bg-primary text-white hover:bg-primary-light',
+    secondary: 'bg-secondary text-white hover:bg-secondary-light',
+  }
+  const disabledClasses = disabled ? 'opacity-50 cursor-not-allowed' : ''
+  return (
+    <button
+      {...props}
+      disabled={disabled}
+      className={`${base} ${variants[variant]} ${disabledClasses} ${className}`}
+    />
+  )
+}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement>
+
+export default function Card({ className = '', ...props }: CardProps) {
+  return (
+    <div
+      {...props}
+      className={`bg-white dark:bg-gray-800 rounded shadow ${className}`}
+    />
+  )
+}

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+export function Input({ className = '', ...props }: InputProps) {
+  return (
+    <input
+      {...props}
+      className={`w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary ${className}`}
+    />
+  )
+}
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
+
+export function Textarea({ className = '', ...props }: TextareaProps) {
+  return (
+    <textarea
+      {...props}
+      className={`w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary ${className}`}
+    />
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,15 +2,15 @@
 
 body {
   min-height: 100vh;
-  font-family: Inter, system-ui, sans-serif;
-  background-color: #f9fafb; /* gray-50 */
-  color: #1f2937; /* gray-800 */
+  font-family: Inter, Roboto, system-ui, sans-serif;
+  background-color: #ffffff;
+  color: #1e293b; /* slate-800 */
 }
 
 @media (prefers-color-scheme: dark) {
   body {
-    background-color: #111827; /* gray-900 */
-    color: #e5e7eb; /* gray-200 */
+    background-color: #36454F; /* charcoal */
+    color: #f9fafb;
   }
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { ThemeProvider } from '@material-tailwind/react'
 import './index.css'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
+    <App />
   </StrictMode>,
 )

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -6,7 +6,17 @@ const config: Config = withMT({
   content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', 'Roboto', 'ui-sans-serif', 'system-ui'],
+      },
       colors: {
+        navy: '#1e40af',
+        charcoal: '#36454F',
+        accent: {
+          DEFAULT: '#f59e0b',
+          light: '#fcd34d',
+          dark: '#b45309',
+        },
         primary: {
           DEFAULT: '#2563eb',
           light: '#3b82f6',


### PR DESCRIPTION
## Summary
- tweak Tailwind config with custom fonts and colors
- add base styles for light/dark themes
- add new reusable Button, Card and Input components
- refactor App to use new components instead of MaterialTailwind
- drop ThemeProvider wrapper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6878fd532d44832f8eebee207cd100e1