### PR TITLE
Add responsive header and sidebar layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,10 +4,10 @@ import Card from './components/ui/Card'
 import QueryEditor from './components/QueryEditor'
 import DataTable from './components/DataTable'
 import ChartView from './components/charts/ChartView'
-import SchemaExplorer from './components/SchemaExplorer'
 import Spinner from './components/Spinner'
 import { queryDatabase, type VisualSpec } from './api'
 import { useQueryHistory } from './hooks/useQueryHistory'
+import MainLayout from './layout/MainLayout'
 
 function normalizeInput(text: string): string {
   return text.trim().replace(/\s+/g, ' ').toLocaleLowerCase('tr-TR')
@@ -62,100 +62,82 @@ export default function App() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="bg-gray-100">
-        <div className="max-w-7xl mx-auto flex items-center justify-between p-4">
-          <h1 className="text-2xl font-bold">Visual DataBase</h1>
-          <div className="w-8 h-8 rounded-full bg-gray-300" />
-        </div>
-      </header>
-      <main className="flex-1 max-w-7xl mx-auto p-6">
-        <div className="grid grid-cols-4 gap-8">
-          <div className="col-span-4 lg:col-span-3 flex flex-col space-y-6">
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <QueryEditor
-                value={question}
-                onChange={setQuestion}
-                error={formError}
-                disabled={loading}
-              />
-              <div className="flex gap-2">
-                <Button
-                  type="submit"
-                  className="flex-1 text-base"
-                  disabled={loading || !question.trim()}
-                >
-                  {loading ? 'Çalışıyor...' : 'ASK'}
-                </Button>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={handleSave}
-                  disabled={!question.trim()}
-                >
-                  Save
-                </Button>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={handleLoad}
-                >
-                  Load
-                </Button>
-              </div>
-            </form>
-            {error && <p className="text-red-600">{error}</p>}
-            {loading && (
-              <div className="flex justify-center py-4">
-                <Spinner />
-              </div>
-            )}
-            {result && (
-              <div className="space-y-6">
-                {result.map((vis, idx) => (
-                  <Card key={idx}>
-                    <div className="p-4 space-y-4">
-                      {vis.type !== 'table' && vis.x && vis.y && (
-                        <h2 className="text-lg font-semibold">
-                          {Array.isArray(vis.y) ? vis.y.join(', ') : vis.y} vs {vis.x}
-                        </h2>
-                      )}
-                      {sql && (
-                        <p className="text-sm break-all font-mono">{sql}</p>
-                      )}
-                      {vis.type === 'table' ? (
-                        <DataTable data={vis.data} />
-                      ) : (
-                        <ChartView
-                          data={vis.data}
-                          chartType={
-                            vis.type as
-                              | 'bar'
-                              | 'line'
-                              | 'scatter'
-                              | 'pie'
-                              | 'doughnut'
-                          }
-                          x={vis.x!}
-                          y={vis.y!}
-                        />
-                      )}
-                    </div>
-                  </Card>
-                ))}
-              </div>
-            )}
+    <MainLayout onFieldSelect={handleFieldSelect}>
+      <div className="max-w-5xl mx-auto space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <QueryEditor
+            value={question}
+            onChange={setQuestion}
+            error={formError}
+            disabled={loading}
+          />
+          <div className="flex gap-2">
+            <Button
+              type="submit"
+              className="flex-1 text-base"
+              disabled={loading || !question.trim()}
+            >
+              {loading ? 'Çalışıyor...' : 'ASK'}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleSave}
+              disabled={!question.trim()}
+            >
+              Save
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleLoad}
+            >
+              Load
+            </Button>
           </div>
-          <div className="col-span-4 lg:col-span-1">
-            <Card className="shadow">
-              <div className="p-2 space-y-2">
-                <h2 className="text-lg font-semibold">Schema Explorer</h2>
-                <SchemaExplorer onSelect={handleFieldSelect} />
-              </div>
-            </Card>
+        </form>
+        {error && <p className="text-red-600">{error}</p>}
+        {loading && (
+          <div className="flex justify-center py-4">
+            <Spinner />
           </div>
-        </div>
-      </main>
-    </div>
+        )}
+        {result && (
+          <div className="space-y-6">
+            {result.map((vis, idx) => (
+              <Card key={idx}>
+                <div className="p-4 space-y-4">
+                  {vis.type !== 'table' && vis.x && vis.y && (
+                    <h2 className="text-lg font-semibold">
+                      {Array.isArray(vis.y) ? vis.y.join(', ') : vis.y} vs {vis.x}
+                    </h2>
+                  )}
+                  {sql && (
+                    <p className="text-sm break-all font-mono">{sql}</p>
+                  )}
+                  {vis.type === 'table' ? (
+                    <DataTable data={vis.data} />
+                  ) : (
+                    <ChartView
+                      data={vis.data}
+                      chartType={
+                        vis.type as
+                          | 'bar'
+                          | 'line'
+                          | 'scatter'
+                          | 'pie'
+                          | 'doughnut'
+                      }
+                      x={vis.x!}
+                      y={vis.y!}
+                    />
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </MainLayout>
   )
 }

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,13 +1,13 @@
-import React, { useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
-  ColumnDef,
+  type ColumnDef,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
-  SortingState,
+  type SortingState,
 } from '@tanstack/react-table'
 import { UserIcon } from '@heroicons/react/20/solid'
 import Button from './ui/Button'

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import reactLogo from '../assets/react.svg'
+import { Cog6ToothIcon } from '@heroicons/react/24/outline'
+
+export default function Header() {
+  const [open, setOpen] = useState(false)
+  const nav = [
+    { label: 'Home', href: '#' },
+    { label: 'History', href: '#' },
+  ]
+
+  return (
+    <header className="bg-primary text-white">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-4">
+          <img src={reactLogo} alt="logo" className="w-8 h-8" />
+          <nav className="hidden md:flex gap-4 text-sm">
+            {nav.map((n) => (
+              <a key={n.label} href={n.href} className="hover:underline">
+                {n.label}
+              </a>
+            ))}
+          </nav>
+        </div>
+        <div className="relative">
+          <button
+            type="button"
+            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center"
+            onClick={() => setOpen((v) => !v)}
+          >
+            <span className="sr-only">User menu</span>
+            <div className="w-6 h-6 rounded-full bg-gray-200" />
+          </button>
+          {open && (
+            <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 rounded shadow-md z-10">
+              <button
+                className="flex items-center gap-2 w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                <Cog6ToothIcon className="w-4 h-4" /> Settings
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/layout/MainLayout.tsx
+++ b/frontend/src/layout/MainLayout.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import Header from './Header'
+import Sidebar from './Sidebar'
+
+interface Props {
+  children: React.ReactNode
+  onFieldSelect: (field: string) => void
+}
+
+export default function MainLayout({ children, onFieldSelect }: Props) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar onFieldSelect={onFieldSelect} />
+        <main className="flex-1 overflow-y-auto p-4 bg-white dark:bg-gray-800">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/20/solid'
+import SchemaExplorer from '../components/SchemaExplorer'
+
+interface Props {
+  onFieldSelect: (field: string) => void
+}
+
+export default function Sidebar({ onFieldSelect }: Props) {
+  const [open, setOpen] = useState(true)
+  const nav = [
+    { label: 'Queries', href: '#' },
+    { label: 'Reports', href: '#' },
+  ]
+
+  return (
+    <aside
+      className={`bg-gray-50 dark:bg-gray-900 border-r dark:border-gray-700 overflow-y-auto transition-all duration-300 ${open ? 'w-64' : 'w-16'}`}
+    >
+      <div className="flex items-center justify-between p-2">
+        {open && <span className="font-semibold">Menu</span>}
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+        >
+          {open ? (
+            <ChevronLeftIcon className="w-5 h-5" />
+          ) : (
+            <ChevronRightIcon className="w-5 h-5" />
+          )}
+        </button>
+      </div>
+      {open && (
+        <nav className="px-2 space-y-1 text-sm">
+          {nav.map((n) => (
+            <a
+              key={n.label}
+              href={n.href}
+              className="block px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+            >
+              {n.label}
+            </a>
+          ))}
+        </nav>
+      )}
+      {open && (
+        <div className="p-2">
+          <SchemaExplorer onSelect={onFieldSelect} />
+        </div>
+      )}
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary
- add Header, Sidebar and MainLayout layout components
- migrate App to new layout
- adjust DataTable types

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687907107864832f887f7620f5390f95