### PR TITLE
Add theme toggle support

### DIFF
--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+})
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useEffect(() => {
+    const stored = (localStorage.getItem('theme') as Theme | null)
+    if (stored) {
+      setTheme(stored)
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((t) => (t === 'light' ? 'dark' : 'light'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTheme() {
+  return useContext(ThemeContext)
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,11 +7,9 @@ body {
   color: #1e293b; /* slate-800 */
 }
 
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: #36454F; /* charcoal */
-    color: #f9fafb;
-  }
+.dark body {
+  background-color: #36454F; /* charcoal */
+  color: #f9fafb;
 }
 
 @layer utilities {

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import reactLogo from '../assets/react.svg'
-import { Cog6ToothIcon } from '@heroicons/react/24/outline'
+import { Cog6ToothIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
+import { useTheme } from '../hooks/useTheme'
 
 export default function Header() {
   const [open, setOpen] = useState(false)
+  const { theme, toggleTheme } = useTheme()
   const nav = [
     { label: 'Home', href: '#' },
     { label: 'History', href: '#' },
@@ -22,7 +24,19 @@ export default function Header() {
             ))}
           </nav>
         </div>
-        <div className="relative">
+        <div className="flex items-center gap-2 relative">
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center"
+          >
+            <span className="sr-only">Toggle theme</span>
+            {theme === 'dark' ? (
+              <SunIcon className="w-5 h-5" />
+            ) : (
+              <MoonIcon className="w-5 h-5" />
+            )}
+          </button>
           <button
             type="button"
             className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
+import { ThemeProvider } from './hooks/useTheme'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -3,6 +3,7 @@ import type { Config } from 'tailwindcss'
 
 const config: Config = withMT({
   mode: 'jit',
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],
   theme: {
     extend: {
@@ -26,6 +27,14 @@ const config: Config = withMT({
           DEFAULT: '#10b981',
           light: '#6ee7b7',
           dark: '#047857',
+        },
+        light: {
+          base: '#ffffff',
+          foreground: '#1e293b',
+        },
+        dark: {
+          base: '#36454F',
+          foreground: '#f9fafb',
         },
       },
     },


### PR DESCRIPTION
## Summary
- configure Tailwind to use class-based dark mode and add light/dark tokens
- provide a `ThemeProvider` hook for storing the current theme
- wrap the app with `ThemeProvider`
- show a theme toggle button in the header
- apply `.dark` body styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68790a67f3d8832f954afde8aab1783a