### PR TITLE
Fix Save/Load button visibility

### DIFF
--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -14,7 +14,10 @@ export default function Button({
     'px-4 py-2 rounded font-medium focus:outline-none transition-colors'
   const variants: Record<string, string> = {
     primary: 'bg-primary text-white hover:bg-primary-light',
-    secondary: 'bg-secondary text-white hover:bg-secondary-light',
+    // Fallback to Tailwind's built-in green classes in case custom colors
+    // from tailwind.config.ts are not generated.
+    secondary:
+      'bg-secondary bg-green-600 text-white hover:bg-secondary-light hover:bg-green-700',
   }
   const disabledClasses = disabled ? 'opacity-50 cursor-not-allowed' : ''
   return (


### PR DESCRIPTION
## Summary
- ensure `secondary` button variant uses a fallback color if custom Tailwind colors are missing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68792b20cf20832f9fdabcd86b73586c