### PR TITLE
Improve dashboard header layout

### DIFF
--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import reactLogo from '../assets/react.svg'
+import companyLogo from '../assets/react.svg'
 import { Cog6ToothIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { useTheme } from '../hooks/useTheme'
 
@@ -12,27 +12,27 @@ export default function Header() {
   ]
 
   return (
-    <header className="bg-primary text-white">
-      <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3">
-        <div className="flex items-center gap-4">
-          <img src={reactLogo} alt="logo" className="w-8 h-8" />
-          <nav className="hidden md:flex gap-4 text-sm">
-            {nav.map((n) => (
-              <a
-                key={n.label}
-                href={n.href}
-                className="hover:underline text-black dark:text-white"
-              >
-                {n.label}
-              </a>
-            ))}
-          </nav>
+    <header className="bg-gray-100 dark:bg-gray-900 shadow-md">
+      <div className="max-w-7xl mx-auto flex items-center h-16 px-4">
+        <div className="flex items-center gap-3">
+          <img src={companyLogo} alt="Company logo" className="w-10 h-10" />
         </div>
-        <div className="flex items-center gap-2 relative">
+        <nav className="flex-1 flex justify-center gap-6 text-sm font-medium">
+          {nav.map((n) => (
+            <a
+              key={n.label}
+              href={n.href}
+              className="hover:underline text-black dark:text-white"
+            >
+              {n.label}
+            </a>
+          ))}
+        </nav>
+        <div className="flex items-center gap-3 relative">
           <button
             type="button"
             onClick={toggleTheme}
-            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center"
+            className="w-9 h-9 rounded-full flex items-center justify-center bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
           >
             <span className="sr-only">Toggle theme</span>
             {theme === 'dark' ? (
@@ -43,17 +43,15 @@ export default function Header() {
           </button>
           <button
             type="button"
-            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center"
+            className="w-9 h-9 rounded-full flex items-center justify-center bg-gray-200 dark:bg-gray-700"
             onClick={() => setOpen((v) => !v)}
           >
             <span className="sr-only">User menu</span>
-            <div className="w-6 h-6 rounded-full bg-gray-200" />
+            <div className="w-7 h-7 rounded-full bg-gray-300 dark:bg-gray-500" />
           </button>
           {open && (
             <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 rounded shadow-md z-10">
-              <button
-                className="flex items-center gap-2 w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-              >
+              <button className="flex items-center gap-2 w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700">
                 <Cog6ToothIcon className="w-4 h-4" /> Settings
               </button>
             </div>


### PR DESCRIPTION
## Summary
- revamp Header with logo, centered navigation, theme toggle and user menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6879314f5b3c832f847af1f9a5f7abbe