### PR TITLE
Toggle dark class on body

### DIFF
--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -26,6 +26,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark')
+    document.body.classList.toggle('dark', theme === 'dark')
     localStorage.setItem('theme', theme)
   }, [theme])
 


### PR DESCRIPTION
## Summary
- toggle `dark` class on `document.body` in theme hook

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6879365e9368832f8cd6f56d1dd0059f