### PR TITLE
Refine UI component styles

### DIFF
--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -11,16 +11,15 @@ export default function Button({
   ...props
 }: ButtonProps) {
   const base =
-    'px-4 py-2 rounded font-medium focus:outline-none transition-colors'
+    'px-8 py-3 rounded-lg font-medium focus:outline-none transition-colors shadow-lg hover:shadow-xl'
   const variants: Record<string, string> = {
     // Provide a fallback to Tailwind's blue palette in case custom colors from
     // tailwind.config.ts are not available.
     primary:
-      'bg-primary bg-blue-600 text-white hover:bg-primary-light hover:bg-blue-700',
-    // Fallback to Tailwind's built-in green classes in case custom colors
-    // from tailwind.config.ts are not generated.
+      'bg-gradient-to-r from-brand-accent to-blue-700 text-white',
+    // Secondary buttons get a neutral style for light and dark modes.
     secondary:
-      'bg-secondary bg-green-600 text-white hover:bg-secondary-light hover:bg-green-700',
+      'bg-neutral-light dark:bg-neutral-dark border border-neutral-medium text-neutral-dark dark:text-neutral-light hover:bg-neutral-medium/50',
   }
   const disabledClasses = disabled ? 'opacity-50 cursor-not-allowed' : ''
   return (

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@ export default function Card({ className = '', ...props }: CardProps) {
   return (
     <div
       {...props}
-      className={`bg-white dark:bg-gray-800 rounded shadow ${className}`}
+      className={`bg-white dark:bg-gray-800 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-700 hover:shadow-2xl transition-shadow ${className}`}
     />
   )
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -49,6 +49,7 @@ const config: Config = withMT({
         },
         'brand-primary': '#1e293b',
         'brand-secondary': '#334155',
+        'brand-accent': '#3b82f6',
       },
     },
   },


### PR DESCRIPTION
## Summary
- implement premium card styling with larger rounding and borders
- give buttons gradient styling and theme-aware secondary variant
- expose `brand-accent` color in Tailwind config

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687943204288832fa33d02f782e9af57