### PR TITLE
Implement premium design touches

### DIFF
--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -1,5 +1,7 @@
 import CodeMirror from '@uiw/react-codemirror'
 import { sql } from '@codemirror/lang-sql'
+import { lineNumbers } from '@codemirror/view'
+import { autocompletion } from '@codemirror/autocomplete'
 import { useQueryHistory } from '../hooks/useQueryHistory'
 
 interface Props {
@@ -17,7 +19,7 @@ export default function QueryEditor({ value, onChange, error, disabled }: Props)
       <CodeMirror
         value={value}
         height="120px"
-        extensions={[sql()]}
+        extensions={[sql(), lineNumbers(), autocompletion()]}
         onChange={(val) => onChange(val)}
         editable={!disabled}
         className={`border rounded ${error ? 'border-red-500' : 'border-gray-300'}`}

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,0 +1,15 @@
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import { Input } from './ui/Input'
+
+export default function SearchBar() {
+  return (
+    <div className="relative">
+      <MagnifyingGlassIcon className="w-5 h-5 text-gray-400 absolute left-2 top-1/2 -translate-y-1/2" />
+      <Input
+        type="text"
+        placeholder="Search..."
+        className="pl-8 w-48"
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/charts/ChartView.tsx
+++ b/frontend/src/components/charts/ChartView.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import type { Chart as ChartJS } from 'chart.js'
 import ChartWrapper, { baseOptions, defaultPalette } from './ChartWrapper'
+import Button from '../ui/Button'
 
 interface Props {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -142,20 +143,12 @@ export default function ChartView({ data, chartType, x, y }: Props) {
             onChange={(e) => setEnd(Number(e.target.value))}
           />
         </label>
-        <button
-          type="button"
-          onClick={handleExportPNG}
-          className="ml-auto px-2 py-1 rounded bg-blue-500 text-white"
-        >
+        <Button onClick={handleExportPNG} className="ml-auto">
           PNG
-        </button>
-        <button
-          type="button"
-          onClick={handleExportPDF}
-          className="px-2 py-1 rounded bg-green-600 text-white"
-        >
+        </Button>
+        <Button variant="secondary" onClick={handleExportPDF}>
           PDF
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/frontend/src/components/charts/ChartWrapper.tsx
+++ b/frontend/src/components/charts/ChartWrapper.tsx
@@ -57,7 +57,13 @@ ChartJS.register(
 )
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const defaultPalette = ['#3b82f6', '#10b981', '#ef4444', '#f59e0b', '#6366f1']
+export const defaultPalette = [
+  '#3b82f6',
+  '#10b981',
+  '#ef4444',
+  '#f59e0b',
+  '#334155',
+]
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const baseOptions = {

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react'
 import companyLogo from '../assets/react.svg'
-import { Cog6ToothIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
+import {
+  Cog6ToothIcon,
+  MoonIcon,
+  SunIcon,
+  BellIcon,
+} from '@heroicons/react/24/outline'
+import SearchBar from '../components/SearchBar'
 import { useTheme } from '../hooks/useTheme'
 
 export default function Header() {
@@ -8,7 +14,9 @@ export default function Header() {
   const { theme, toggleTheme } = useTheme()
   const nav = [
     { label: 'Home', href: '#' },
-    { label: 'History', href: '#' },
+    { label: 'Queries', href: '#' },
+    { label: 'Reports', href: '#' },
+    { label: 'Analytics', href: '#' },
   ]
 
   return (
@@ -32,6 +40,7 @@ export default function Header() {
           ))}
         </nav>
         <div className="flex items-center gap-3 relative">
+          <SearchBar />
           <button
             type="button"
             onClick={toggleTheme}
@@ -43,6 +52,13 @@ export default function Header() {
             ) : (
               <MoonIcon className="w-5 h-5" />
             )}
+          </button>
+          <button
+            type="button"
+            className="w-9 h-9 rounded-full flex items-center justify-center bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+          >
+            <span className="sr-only">Notifications</span>
+            <BellIcon className="w-5 h-5" />
           </button>
           <button
             type="button"

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react'
-import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/20/solid'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  HomeIcon,
+  DocumentMagnifyingGlassIcon,
+  DocumentChartBarIcon,
+  ChartBarIcon,
+} from '@heroicons/react/24/outline'
 import SchemaExplorer from '../components/SchemaExplorer'
 
 interface Props {
@@ -9,13 +16,15 @@ interface Props {
 export default function Sidebar({ onFieldSelect }: Props) {
   const [open, setOpen] = useState(true)
   const nav = [
-    { label: 'Queries', href: '#' },
-    { label: 'Reports', href: '#' },
+    { label: 'Home', href: '#', icon: HomeIcon },
+    { label: 'Queries', href: '#', icon: DocumentMagnifyingGlassIcon },
+    { label: 'Reports', href: '#', icon: DocumentChartBarIcon },
+    { label: 'Analytics', href: '#', icon: ChartBarIcon },
   ]
 
   return (
     <aside
-      className={`bg-gray-50 dark:bg-gray-900 border-r dark:border-gray-700 overflow-y-auto transition-all duration-300 ${open ? 'w-64' : 'w-16'}`}
+      className={`bg-gray-50 dark:bg-gray-900 border-r dark:border-gray-700 overflow-y-auto transition-all duration-300 ${open ? 'w-[280px]' : 'w-16'}`}
     >
       <div className="flex items-center justify-between p-2">
         {open && <span className="font-semibold">Menu</span>}
@@ -31,19 +40,18 @@ export default function Sidebar({ onFieldSelect }: Props) {
           )}
         </button>
       </div>
-      {open && (
-        <nav className="px-2 space-y-1 text-sm">
-          {nav.map((n) => (
-            <a
-              key={n.label}
-              href={n.href}
-              className="block px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
-            >
-              {n.label}
-            </a>
-          ))}
-        </nav>
-      )}
+      <nav className="px-2 space-y-1 text-sm">
+        {nav.map((n) => (
+          <a
+            key={n.label}
+            href={n.href}
+            className="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+          >
+            {n.icon && <n.icon className="w-5 h-5" />}
+            {open && n.label}
+          </a>
+        ))}
+      </nav>
       {open && (
         <div className="p-2">
           <SchemaExplorer onSelect={onFieldSelect} />


### PR DESCRIPTION
## Summary
- add `SearchBar` component and integrate into header
- extend header navigation and add notification icon
- redesign sidebar with wider layout and icons
- enable line numbers and autocomplete in query editor
- tweak chart palette and export buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68796ad4eef4832f9bd57980c31f9673