### PR TITLE
Fix palette usage with standard Tailwind colors

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -96,7 +96,7 @@ export default function DataTable({ data }: Props) {
           return (
             <div className={`flex items-center gap-1 ${colorClass}`}>
               {isCustomerField && (
-                <UserIcon className="w-4 h-4 text-neutral-dark" />
+                <UserIcon className="w-4 h-4 text-slate-500" />
               )}
               {formatValue(val, row.original)}
             </div>
@@ -198,15 +198,15 @@ export default function DataTable({ data }: Props) {
         </div>
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border divide-y divide-neutral-medium dark:divide-neutral-dark">
-          <thead className="bg-neutral-light dark:bg-neutral-black">
+        <table className="min-w-full text-sm border divide-y divide-slate-200 dark:divide-slate-500">
+          <thead className="bg-slate-50 dark:bg-slate-900">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
                     onClick={header.column.getToggleSortingHandler()}
-                    className="px-2 py-1 border border-neutral-medium dark:border-neutral-dark text-left font-semibold select-none cursor-pointer"
+                    className="px-2 py-1 border border-slate-200 dark:border-slate-500 text-left font-semibold select-none cursor-pointer"
                   >
                     {flexRender(
                       header.column.columnDef.header,
@@ -230,12 +230,12 @@ export default function DataTable({ data }: Props) {
             {table.getRowModel().rows.map((row) => (
               <tr
                 key={row.id}
-                className="even:bg-neutral-light dark:even:bg-neutral-black hover:bg-neutral-light dark:hover:bg-neutral-dark"
+                className="even:bg-slate-50 dark:even:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-500"
               >
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}
-                    className="px-2 py-1 border border-neutral-medium dark:border-neutral-dark"
+                    className="px-2 py-1 border border-slate-200 dark:border-slate-500"
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -22,13 +22,13 @@ export default function QueryEditor({ value, onChange, error, disabled }: Props)
         extensions={[sql(), lineNumbers(), autocompletion()]}
         onChange={(val) => onChange(val)}
         editable={!disabled}
-        className={`border rounded ${error ? 'border-red-500' : 'border-neutral-medium'}`}
+        className={`border rounded ${error ? 'border-red-500' : 'border-slate-200'}`}
       />
       {error && <p className="text-red-600 text-sm">{error}</p>}
       {history.length > 0 && (
         <select
           onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded border border-neutral-medium dark:border-neutral-dark p-1 bg-white dark:bg-neutral-dark text-neutral-black dark:text-neutral-light"
+          className="w-full rounded border border-slate-200 dark:border-slate-500 p-1 bg-white dark:bg-slate-500 text-slate-900 dark:text-slate-50"
         >
           <option value="">Recent Queries</option>
           {history.map((h, idx) => (

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -16,10 +16,10 @@ export default function Button({
     // Provide a fallback to Tailwind's blue palette in case custom colors from
     // tailwind.config.ts are not available.
     primary:
-      'bg-gradient-to-r from-brand-accent to-accent-dark text-white',
+      'bg-gradient-to-r from-blue-500 to-blue-700 text-white',
     // Secondary buttons get a neutral style for light and dark modes.
     secondary:
-      'bg-neutral-light dark:bg-neutral-dark border border-neutral-medium text-neutral-dark dark:text-neutral-light hover:bg-neutral-medium/50',
+      'bg-slate-50 dark:bg-slate-500 border border-slate-200 text-slate-500 dark:text-slate-50 hover:bg-slate-200/50',
   }
   const disabledClasses = disabled ? 'opacity-50 cursor-not-allowed' : ''
   return (

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@ export default function Card({ className = '', ...props }: CardProps) {
   return (
     <div
       {...props}
-      className={`bg-gradient-to-br from-neutral-white to-neutral-light dark:from-neutral-dark dark:to-neutral-black rounded-2xl shadow-xl border border-neutral-medium dark:border-neutral-dark hover:shadow-2xl transition-shadow ${className}`}
+      className={`bg-gradient-to-br from-white to-slate-50 dark:from-slate-500 dark:to-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-500 hover:shadow-2xl transition-shadow ${className}`}
     />
   )
 }

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -6,7 +6,7 @@ export function Input({ className = '', ...props }: InputProps) {
   return (
     <input
       {...props}
-      className={`w-full rounded border border-neutral-medium dark:border-neutral-dark bg-white dark:bg-neutral-dark px-3 py-2 text-neutral-black dark:text-neutral-light placeholder-neutral-dark dark:placeholder-neutral-dark focus:outline-none focus:ring-2 focus:ring-primary ${className}`}
+      className={`w-full rounded border border-slate-200 dark:border-slate-500 bg-white dark:bg-slate-500 px-3 py-2 text-slate-900 dark:text-slate-50 placeholder-slate-500 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-800 ${className}`}
     />
   )
 }
@@ -17,7 +17,7 @@ export function Textarea({ className = '', ...props }: TextareaProps) {
   return (
     <textarea
       {...props}
-      className={`w-full rounded border border-neutral-medium dark:border-neutral-dark bg-white dark:bg-neutral-dark px-3 py-2 text-neutral-black dark:text-neutral-light placeholder-neutral-dark dark:placeholder-neutral-dark focus:outline-none focus:ring-2 focus:ring-primary ${className}`}
+      className={`w-full rounded border border-slate-200 dark:border-slate-500 bg-white dark:bg-slate-500 px-3 py-2 text-slate-900 dark:text-slate-50 placeholder-slate-500 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-800 ${className}`}
     />
   )
 }

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -20,11 +20,11 @@ export default function Header() {
   ]
 
   return (
-    <header className="h-20 bg-gradient-to-r from-brand-primary to-brand-secondary shadow-xl">
+    <header className="h-20 bg-gradient-to-r from-slate-800 to-slate-700 shadow-xl">
       <div className="max-w-7xl mx-auto flex items-center justify-between h-full px-8">
         <div className="flex items-center gap-3">
           <img src={companyLogo} alt="Company logo" className="w-10 h-10" />
-          <span className="font-bold text-lg text-neutral-black dark:text-white">
+          <span className="font-bold text-lg text-slate-900 dark:text-white">
             Visual DataBase
           </span>
         </div>
@@ -44,7 +44,7 @@ export default function Header() {
           <button
             type="button"
             onClick={toggleTheme}
-          className="w-9 h-9 rounded-full flex items-center justify-center bg-neutral-medium text-neutral-dark dark:bg-neutral-dark dark:text-neutral-light"
+          className="w-9 h-9 rounded-full flex items-center justify-center bg-slate-200 text-slate-500 dark:bg-slate-500 dark:text-slate-50"
           >
             <span className="sr-only">Toggle theme</span>
             {theme === 'dark' ? (
@@ -55,27 +55,27 @@ export default function Header() {
           </button>
           <button
             type="button"
-          className="w-9 h-9 rounded-full flex items-center justify-center bg-neutral-medium text-neutral-dark dark:bg-neutral-dark dark:text-neutral-light"
+          className="w-9 h-9 rounded-full flex items-center justify-center bg-slate-200 text-slate-500 dark:bg-slate-500 dark:text-slate-50"
           >
             <span className="sr-only">Notifications</span>
             <BellIcon className="w-5 h-5" />
           </button>
           <button
             type="button"
-          className="w-9 h-9 rounded-full flex items-center justify-center bg-neutral-medium dark:bg-neutral-dark"
+          className="w-9 h-9 rounded-full flex items-center justify-center bg-slate-200 dark:bg-slate-500"
             onClick={() => setOpen((v) => !v)}
           >
             <span className="sr-only">User menu</span>
-            <div className="w-7 h-7 rounded-full bg-neutral-medium dark:bg-neutral-dark" />
+            <div className="w-7 h-7 rounded-full bg-slate-200 dark:bg-slate-500" />
           </button>
           {open && (
-            <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-neutral-black text-neutral-dark dark:text-neutral-light rounded shadow-md z-10">
+            <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-slate-900 text-slate-500 dark:text-slate-50 rounded shadow-md z-10">
               <button
                 onClick={() => {
                   setOpen(false)
                   // TODO: implement settings behaviour
                 }}
-                className="flex items-center gap-2 w-full text-left px-3 py-2 hover:bg-neutral-light dark:hover:bg-neutral-dark"
+                className="flex items-center gap-2 w-full text-left px-3 py-2 hover:bg-slate-50 dark:hover:bg-slate-500"
               >
                 <Cog6ToothIcon className="w-4 h-4" /> Settings
               </button>

--- a/frontend/src/layout/MainLayout.tsx
+++ b/frontend/src/layout/MainLayout.tsx
@@ -13,7 +13,7 @@ export default function MainLayout({ children, onFieldSelect }: Props) {
       <Header />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar onFieldSelect={onFieldSelect} />
-        <main className="flex-1 overflow-y-auto p-4 bg-white dark:bg-neutral-black">
+        <main className="flex-1 overflow-y-auto p-4 bg-white dark:bg-slate-900">
           {children}
         </main>
       </div>

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -24,14 +24,14 @@ export default function Sidebar({ onFieldSelect }: Props) {
 
   return (
     <aside
-      className={`bg-neutral-light dark:bg-neutral-black border-r dark:border-neutral-dark overflow-y-auto transition-all duration-300 ${open ? 'w-[280px]' : 'w-16'}`}
+      className={`bg-slate-50 dark:bg-slate-900 border-r dark:border-slate-500 overflow-y-auto transition-all duration-300 ${open ? 'w-[280px]' : 'w-16'}`}
     >
       <div className="flex items-center justify-between p-2">
         {open && <span className="font-semibold">Menu</span>}
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className="p-1 rounded hover:bg-neutral-medium dark:hover:bg-neutral-dark"
+          className="p-1 rounded hover:bg-slate-200 dark:hover:bg-slate-500"
         >
           {open ? (
             <ChevronLeftIcon className="w-5 h-5" />
@@ -45,7 +45,7 @@ export default function Sidebar({ onFieldSelect }: Props) {
           <a
             key={n.label}
             href={n.href}
-            className="flex items-center gap-2 px-2 py-1 rounded hover:bg-neutral-medium dark:hover:bg-neutral-dark"
+            className="flex items-center gap-2 px-2 py-1 rounded hover:bg-slate-200 dark:hover:bg-slate-500"
           >
             {n.icon && <n.icon className="w-5 h-5" />}
             {open && n.label}


### PR DESCRIPTION
## Summary
- switch custom brand color classes to built-in Tailwind palette
- update gradients, backgrounds and borders

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687970229c2c832fb3f5ccd135d7f673