### PR TITLE
Update Button and Card UI styles

### DIFF
--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -14,7 +14,7 @@ export default function Button({
     'px-8 py-3 rounded-lg font-medium focus:outline-none transition-colors shadow-lg hover:shadow-xl'
   const variants: Record<string, string> = {
     primary:
-      'bg-gradient-accent text-white',
+      'bg-brand-accent text-white',
     secondary:
       'bg-neutral-light dark:bg-brand-secondary border border-neutral-medium text-brand-secondary dark:text-neutral-light hover:bg-neutral-medium/50',
   }

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@ export default function Card({ className = '', ...props }: CardProps) {
   return (
     <div
       {...props}
-      className={`bg-gradient-card dark:bg-gradient-to-br dark:from-brand-secondary dark:to-brand-primary rounded-2xl shadow-xl border border-neutral-medium dark:border-neutral-dark hover:shadow-2xl transition-shadow ${className}`}
+      className={`bg-neutral-white dark:bg-brand-secondary rounded-2xl shadow-xl border border-neutral-medium dark:border-neutral-dark hover:shadow-2xl transition-shadow ${className}`}
     />
   )
 }


### PR DESCRIPTION
## Summary
- tweak Button primary variant to use `bg-brand-accent`
- update Card background classes

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_687996d7ecac832fb3dc84c14cbdd126