### PR TITLE
Update UI with corporate blue palette

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -96,7 +96,7 @@ export default function DataTable({ data }: Props) {
           return (
             <div className={`flex items-center gap-1 ${colorClass}`}>
               {isCustomerField && (
-                <UserIcon className="w-4 h-4 text-slate-500" />
+                <UserIcon className="w-4 h-4 text-blue-400" />
               )}
               {formatValue(val, row.original)}
             </div>
@@ -198,15 +198,15 @@ export default function DataTable({ data }: Props) {
         </div>
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border divide-y divide-slate-200 dark:divide-slate-500">
-          <thead className="bg-slate-50 dark:bg-slate-900">
+        <table className="min-w-full text-sm border divide-y divide-blue-200 dark:divide-blue-700">
+          <thead className="bg-blue-50 dark:bg-blue-900">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
                     onClick={header.column.getToggleSortingHandler()}
-                    className="px-2 py-1 border border-slate-200 dark:border-slate-500 text-left font-semibold select-none cursor-pointer"
+                  className="px-2 py-1 border border-blue-200 dark:border-blue-700 text-left font-semibold select-none cursor-pointer"
                   >
                     {flexRender(
                       header.column.columnDef.header,
@@ -230,12 +230,12 @@ export default function DataTable({ data }: Props) {
             {table.getRowModel().rows.map((row) => (
               <tr
                 key={row.id}
-                className="even:bg-slate-50 dark:even:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-500"
+                className="even:bg-blue-50 dark:even:bg-blue-900 hover:bg-blue-100 dark:hover:bg-blue-800"
               >
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}
-                    className="px-2 py-1 border border-slate-200 dark:border-slate-500"
+                    className="px-2 py-1 border border-blue-200 dark:border-blue-700"
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
@@ -251,7 +251,7 @@ export default function DataTable({ data }: Props) {
             type="button"
             onClick={() => table.previousPage()}
             disabled={!table.getCanPreviousPage()}
-            className="px-2 py-1 text-black dark:text-white"
+            className="px-2 py-1 text-blue-900 dark:text-blue-100"
             variant="secondary"
           >
             Prev
@@ -260,7 +260,7 @@ export default function DataTable({ data }: Props) {
             type="button"
             onClick={() => table.nextPage()}
             disabled={!table.getCanNextPage()}
-            className="px-2 py-1 text-black dark:text-white"
+            className="px-2 py-1 text-blue-900 dark:text-blue-100"
             variant="secondary"
           >
             Next

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -22,13 +22,13 @@ export default function QueryEditor({ value, onChange, error, disabled }: Props)
         extensions={[sql(), lineNumbers(), autocompletion()]}
         onChange={(val) => onChange(val)}
         editable={!disabled}
-        className={`border rounded ${error ? 'border-red-500' : 'border-slate-200'}`}
+        className={`border rounded ${error ? 'border-red-500' : 'border-blue-200 dark:border-blue-700'}`}
       />
       {error && <p className="text-red-600 text-sm">{error}</p>}
       {history.length > 0 && (
         <select
           onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded border border-slate-200 dark:border-slate-500 p-1 bg-white dark:bg-slate-500 text-slate-900 dark:text-slate-50"
+          className="w-full rounded border border-blue-200 dark:border-blue-700 p-1 bg-white dark:bg-blue-900 text-blue-900 dark:text-blue-100"
         >
           <option value="">Recent Queries</option>
           {history.map((h, idx) => (

--- a/frontend/src/components/SchemaExplorer.tsx
+++ b/frontend/src/components/SchemaExplorer.tsx
@@ -44,14 +44,14 @@ export default function SchemaExplorer({ onSelect }: Props) {
   })
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-2 overflow-y-auto max-h-[80vh] w-full">
-      <h3 className="font-semibold mb-2 text-lg">Schema Explorer</h3>
+    <div className="bg-white dark:bg-blue-900 rounded-lg shadow p-2 overflow-y-auto max-h-[80vh] w-full">
+      <h3 className="font-semibold mb-2 text-lg text-blue-700 dark:text-blue-300">Schema Explorer</h3>
       <input
         type="text"
         placeholder="Search"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
-        className="w-full mb-2 rounded border border-gray-300 dark:border-gray-600 p-1"
+        className="w-full mb-2 rounded border border-blue-200 dark:border-blue-700 bg-blue-100 dark:bg-blue-800 placeholder-blue-400 p-1"
       />
       <div className="space-y-2">
         {filtered.map((tbl) => (
@@ -61,7 +61,7 @@ export default function SchemaExplorer({ onSelect }: Props) {
               {(tbl.columns ?? []).map((col) => (
                 <li
                   key={col.name}
-                  className="cursor-pointer hover:text-primary"
+                  className="cursor-pointer hover:text-blue-600 dark:hover:text-blue-300"
                   title={col.fk ? `FK -> ${col.fk.table}.${col.fk.column}` : ''}
                   onClick={() => onSelect(`${tbl.name}.${col.name}`)}
                 >

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -4,11 +4,11 @@ import { Input } from './ui/Input'
 export default function SearchBar() {
   return (
     <div className="relative">
-      <MagnifyingGlassIcon className="w-5 h-5 text-gray-400 absolute left-2 top-1/2 -translate-y-1/2" />
+      <MagnifyingGlassIcon className="w-5 h-5 text-blue-400 absolute left-2 top-1/2 -translate-y-1/2" />
       <Input
         type="text"
         placeholder="Search..."
-        className="pl-8 w-48"
+        className="pl-8 w-48 bg-blue-100 dark:bg-blue-800 border-blue-200 dark:border-blue-700 placeholder-blue-400"
       />
     </div>
   )

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -2,7 +2,7 @@ export default function Spinner() {
   return (
     <div role="status" className="flex items-center justify-center">
       <svg
-        className="w-8 h-8 animate-spin text-primary"
+        className="w-8 h-8 animate-spin text-blue-600 dark:text-blue-400"
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -13,9 +13,9 @@ export default function Button({
   const base =
     'px-8 py-3 rounded-lg font-medium focus:outline-none transition-colors shadow-lg hover:shadow-xl'
   const variants: Record<string, string> = {
-    primary: 'bg-blue-600 text-white hover:bg-blue-700',
+    primary: 'bg-blue-600 hover:bg-blue-700 text-white',
     secondary:
-      'bg-gray-100 dark:bg-slate-700 border border-slate-200 text-slate-700 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600',
+      'bg-blue-100 hover:bg-blue-200 dark:bg-blue-800 dark:hover:bg-blue-700 border border-blue-300 dark:border-blue-600 text-blue-900 dark:text-blue-100',
   }
   const disabledClasses = disabled ? 'opacity-50 cursor-not-allowed' : ''
   return (

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@ export default function Card({ className = '', ...props }: CardProps) {
   return (
     <div
       {...props}
-      className={`bg-white dark:bg-slate-700 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-500 hover:shadow-2xl transition-shadow ${className}`}
+      className={`bg-white dark:bg-blue-900 rounded-2xl shadow-xl border border-blue-100 dark:border-blue-700 hover:shadow-2xl transition-shadow ${className}`}
     />
   )
 }

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -6,7 +6,7 @@ export function Input({ className = '', ...props }: InputProps) {
   return (
     <input
       {...props}
-      className={`w-full rounded border border-slate-200 dark:border-slate-500 bg-white dark:bg-slate-500 px-3 py-2 text-slate-900 dark:text-slate-50 placeholder-slate-500 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-800 ${className}`}
+      className={`w-full rounded border border-blue-300 dark:border-blue-700 bg-white dark:bg-blue-900 px-3 py-2 text-blue-900 dark:text-blue-100 placeholder-blue-400 dark:placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-800 ${className}`}
     />
   )
 }
@@ -17,7 +17,7 @@ export function Textarea({ className = '', ...props }: TextareaProps) {
   return (
     <textarea
       {...props}
-      className={`w-full rounded border border-slate-200 dark:border-slate-500 bg-white dark:bg-slate-500 px-3 py-2 text-slate-900 dark:text-slate-50 placeholder-slate-500 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-800 ${className}`}
+      className={`w-full rounded border border-blue-300 dark:border-blue-700 bg-white dark:bg-blue-900 px-3 py-2 text-blue-900 dark:text-blue-100 placeholder-blue-400 dark:placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-800 ${className}`}
     />
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,13 +3,13 @@
 body {
   min-height: 100vh;
   font-family: Inter, Roboto, system-ui, sans-serif;
-  background-color: #ffffff;
-  color: #1e293b; /* slate-800 */
+  background-color: #f8fafc; /* blue-50 */
+  color: #1e3a8a; /* blue-900 */
 }
 
 .dark body {
-  background-color: #0f172a; /* near-black brand */
-  color: #f9fafc;
+  background-color: #0c1132; /* blue-950 */
+  color: #dbeafe; /* blue-100 */
 }
 
 @layer utilities {

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -20,11 +20,11 @@ export default function Header() {
   ]
 
   return (
-    <header className="h-20 bg-gradient-to-r from-blue-50 to-blue-100 shadow-xl">
+    <header className="h-20 bg-blue-900 dark:bg-blue-950 text-white shadow-xl">
       <div className="w-full flex items-center justify-between h-full pl-2 pr-8">
         <div className="flex items-center gap-3">
           <img src={companyLogo} alt="Company logo" className="w-10 h-10" />
-          <span className="font-bold text-lg text-slate-900 dark:text-white">
+          <span className="font-bold text-lg text-white">
             Visual DataBase
           </span>
         </div>
@@ -33,7 +33,7 @@ export default function Header() {
             <a
               key={n.label}
               href={n.href}
-              className="hover:underline text-black dark:text-white"
+              className="hover:underline text-white"
             >
               {n.label}
             </a>
@@ -44,7 +44,7 @@ export default function Header() {
           <button
             type="button"
             onClick={toggleTheme}
-          className="w-9 h-9 rounded-full flex items-center justify-center bg-slate-200 text-slate-500 dark:bg-slate-500 dark:text-slate-50"
+          className="w-9 h-9 rounded-full flex items-center justify-center bg-blue-800 text-blue-200 dark:bg-blue-700 dark:text-blue-200"
           >
             <span className="sr-only">Toggle theme</span>
             {theme === 'dark' ? (
@@ -55,27 +55,27 @@ export default function Header() {
           </button>
           <button
             type="button"
-          className="w-9 h-9 rounded-full flex items-center justify-center bg-slate-200 text-slate-500 dark:bg-slate-500 dark:text-slate-50"
+          className="w-9 h-9 rounded-full flex items-center justify-center bg-blue-800 text-blue-200 dark:bg-blue-700 dark:text-blue-200"
           >
             <span className="sr-only">Notifications</span>
             <BellIcon className="w-5 h-5" />
           </button>
           <button
             type="button"
-          className="w-9 h-9 rounded-full flex items-center justify-center bg-slate-200 dark:bg-slate-500"
+          className="w-9 h-9 rounded-full flex items-center justify-center bg-blue-800 dark:bg-blue-700"
             onClick={() => setOpen((v) => !v)}
           >
             <span className="sr-only">User menu</span>
-            <div className="w-7 h-7 rounded-full bg-slate-200 dark:bg-slate-500" />
+            <div className="w-7 h-7 rounded-full bg-blue-200 dark:bg-blue-500" />
           </button>
           {open && (
-            <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-slate-900 text-slate-500 dark:text-slate-50 rounded shadow-md z-10">
+            <div className="absolute right-0 mt-2 w-40 bg-blue-50 dark:bg-blue-900 text-blue-900 dark:text-blue-100 rounded shadow-md z-10">
               <button
                 onClick={() => {
                   setOpen(false)
                   // TODO: implement settings behaviour
                 }}
-                className="flex items-center gap-2 w-full text-left px-3 py-2 hover:bg-slate-50 dark:hover:bg-slate-500"
+                className="flex items-center gap-2 w-full text-left px-3 py-2 hover:bg-blue-100 dark:hover:bg-blue-800"
               >
                 <Cog6ToothIcon className="w-4 h-4" /> Settings
               </button>

--- a/frontend/src/layout/MainLayout.tsx
+++ b/frontend/src/layout/MainLayout.tsx
@@ -13,7 +13,7 @@ export default function MainLayout({ children, onFieldSelect }: Props) {
       <Header />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar onFieldSelect={onFieldSelect} />
-        <main className="flex-1 overflow-y-auto p-4 bg-white dark:bg-slate-900">
+        <main className="flex-1 overflow-y-auto p-4 bg-blue-50 dark:bg-blue-950">
           {children}
         </main>
       </div>

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -24,14 +24,14 @@ export default function Sidebar({ onFieldSelect }: Props) {
 
   return (
     <aside
-      className={`bg-slate-50 dark:bg-slate-900 border-r dark:border-slate-500 overflow-y-auto transition-all duration-300 ${open ? 'w-[280px]' : 'w-16'}`}
+      className={`bg-blue-50 dark:bg-blue-950 border-r border-blue-200 dark:border-blue-900 overflow-y-auto transition-all duration-300 ${open ? 'w-[280px]' : 'w-16'}`}
     >
       <div className="flex items-center justify-between p-2">
-        {open && <span className="font-semibold">Menu</span>}
+        {open && <span className="font-semibold text-blue-900 dark:text-blue-100">Menu</span>}
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className="p-1 rounded hover:bg-slate-200 dark:hover:bg-slate-500"
+          className="p-1 rounded hover:bg-blue-100 dark:hover:bg-blue-800"
         >
           {open ? (
             <ChevronLeftIcon className="w-5 h-5" />
@@ -45,9 +45,9 @@ export default function Sidebar({ onFieldSelect }: Props) {
           <a
             key={n.label}
             href={n.href}
-            className="flex items-center gap-2 px-2 py-1 rounded hover:bg-slate-200 dark:hover:bg-slate-500"
+            className="flex items-center gap-2 px-2 py-1 rounded text-blue-900 dark:text-blue-100 hover:bg-blue-100 dark:hover:bg-blue-800"
           >
-            {n.icon && <n.icon className="w-5 h-5" />}
+            {n.icon && <n.icon className="w-5 h-5 text-blue-400" />}
             {open && n.label}
           </a>
         ))}


### PR DESCRIPTION
## Summary
- overhaul layout to use blue corporate palette
- adapt buttons, cards and inputs to blue scheme with dark mode
- update schema explorer, header and sidebar for new colors
- tweak table styling and global body colors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687ab4427d50832f9aca41fa3a3acac4